### PR TITLE
adding in initial functions that we use in the github helper class

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,128 @@
+'use strict';
+/* eslint-disable no-underscore-dangle */
+const Joi = require('joi');
+
+class ScmBase {
+    /**
+     * Constructor for Scm
+     * @method constructor
+     * @param  {Object}    config Configuration
+     * @return {ScmBase}
+     */
+    constructor(config) {
+        this.config = config;
+    }
+
+    /**
+     * Reload configuration
+     * @method configure
+     * @param  {Object}     config      Configuration
+     */
+    configure(config) {
+        this.config = config;
+    }
+
+    /**
+     * Format the scmUrl for the specific source control
+     * @method formatScmUrl
+     * @param {String}    scmUrl        Scm Url to format properly
+     */
+    formatScmUrl() {
+        throw new Error('formatScmUrl not implemented');
+    }
+
+    /**
+     * Get a users permissions on a repository
+     * @method getPermissions
+     * @param  {Object}   config            Configuration
+     * @param  {String}   config.scmUrl     The scmUrl to get permissions on
+     * @param  {String}   config.user       The user to get pemissions for
+     * @param  {String}   config.token      The token used to authenticate to the SCM
+     * @return {Promise}
+     */
+    getPermissions(config) {
+        const result = Joi.validate(config, {
+            scmUrl: Joi.string().required(),
+            user: Joi.string().required(),
+            token: Joi.string().required()
+        });
+
+        if (result.error) {
+            return new Promise((resolve, reject) => {
+                process.nextTick(() => reject(result.error));
+            });
+        }
+
+        return this._getPermissions(config);
+    }
+
+    _getPermissions() {
+        return new Promise((resolve, reject) => {
+            process.nextTick(() => reject('not implemented'));
+        });
+    }
+
+    /**
+     * Get a commit sha for a specific repo#branch
+     * @method getCommitSha
+     * @param  {Object}   config            Configuration
+     * @param  {String}   config.scmUrl     The scmUrl to get commit sha of
+     * @param  {String}   config.token      The token used to authenticate to the SCM
+     * @return {Promise}
+     */
+    getCommitSha(config) {
+        const result = Joi.validate(config, {
+            scmUrl: Joi.string().required(),
+            token: Joi.string().required()
+        });
+
+        if (result.error) {
+            return new Promise((resolve, reject) => {
+                process.nextTick(() => reject(result.error));
+            });
+        }
+
+        return this._getCommitSha(config);
+    }
+
+    _getCommitSha() {
+        return new Promise((resolve, reject) => {
+            process.nextTick(() => reject('not implemented'));
+        });
+    }
+
+    /**
+     * Update the commit status for a given repo and sha
+     * @method get
+     * @param  {Object}   config              Configuration
+     * @param  {String}   config.scmUrl       The scmUrl to get permissions on
+     * @param  {String}   config.sha          The sha to apply the status to
+     * @param  {String}   config.buildStatus  The build status used for figuring out the commit status to set
+     * @param  {String}   config.token        The token used to authenticate to the SCM
+     * @return {Promise}
+     */
+    updateCommitStatus(config) {
+        const result = Joi.validate(config, {
+            scmUrl: Joi.string().required(),
+            sha: Joi.string().required(),
+            buildStatus: Joi.string().required(),
+            token: Joi.string().required()
+        });
+
+        if (result.error) {
+            return new Promise((resolve, reject) => {
+                process.nextTick(() => reject(result.error));
+            });
+        }
+
+        return this._updateCommitStatus(config);
+    }
+
+    _updateCommitStatus() {
+        return new Promise((resolve, reject) => {
+            process.nextTick(() => reject('not implemented'));
+        });
+    }
+}
+
+module.exports = ScmBase;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 /* eslint-disable no-underscore-dangle */
 const Joi = require('joi');
+const dataSchema = require('screwdriver-data-schema');
 
 class ScmBase {
     /**
@@ -36,16 +37,11 @@ class ScmBase {
      * @method getPermissions
      * @param  {Object}   config            Configuration
      * @param  {String}   config.scmUrl     The scmUrl to get permissions on
-     * @param  {String}   config.user       The user to get pemissions for
      * @param  {String}   config.token      The token used to authenticate to the SCM
      * @return {Promise}
      */
     getPermissions(config) {
-        const result = Joi.validate(config, {
-            scmUrl: Joi.string().required(),
-            user: Joi.string().required(),
-            token: Joi.string().required()
-        });
+        const result = Joi.validate(config, dataSchema.plugins.scm.getPermissions);
 
         if (result.error) {
             return new Promise((resolve, reject) => {
@@ -71,10 +67,7 @@ class ScmBase {
      * @return {Promise}
      */
     getCommitSha(config) {
-        const result = Joi.validate(config, {
-            scmUrl: Joi.string().required(),
-            token: Joi.string().required()
-        });
+        const result = Joi.validate(config, dataSchema.plugins.scm.getCommitSha);
 
         if (result.error) {
             return new Promise((resolve, reject) => {
@@ -102,12 +95,7 @@ class ScmBase {
      * @return {Promise}
      */
     updateCommitStatus(config) {
-        const result = Joi.validate(config, {
-            scmUrl: Joi.string().required(),
-            sha: Joi.string().required(),
-            buildStatus: Joi.string().required(),
-            token: Joi.string().required()
-        });
+        const result = Joi.validate(config, dataSchema.plugins.scm.updateCommitStatus);
 
         if (result.error) {
             return new Promise((resolve, reject) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-scm-base",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Base class for defining the behavior between screwdriver and source control management systems",
   "main": "index.js",
   "scripts": {
@@ -34,9 +34,11 @@
     "eslint": "^3.2.2",
     "eslint-config-screwdriver": "^2.0.0",
     "eslint-plugin-import": "^1.12.0",
-    "jenkins-mocha": "^2.6.0"
+    "jenkins-mocha": "^2.6.0",
+    "mockery": "^1.7.0"
   },
   "dependencies": {
-    "joi": "^9.0.4"
+    "joi": "^9.0.4",
+    "screwdriver-data-schema": "^9.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,5 +36,7 @@
     "eslint-plugin-import": "^1.12.0",
     "jenkins-mocha": "^2.6.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "joi": "^9.0.4"
+  }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,8 +1,124 @@
 'use strict';
+/* eslint-disable no-underscore-dangle */
 const assert = require('chai').assert;
 
 describe('index test', () => {
-    it('fails', () => {
-        assert.isTrue(false);
+    let instance;
+    let ScmBase;
+
+    beforeEach(() => {
+        /* eslint-disable global-require */
+        ScmBase = require('../index');
+        /* eslint-enable global-require */
+
+        instance = new ScmBase({ foo: 'bar' });
+    });
+
+    afterEach(() => {
+        instance = null;
+    });
+
+    it('can create an scm base class', () => {
+        assert.instanceOf(instance, ScmBase);
+    });
+
+    describe('configure', () => {
+        it('has a configure method', () => {
+            assert.isFunction(instance.configure);
+            instance.configure({});
+        });
+    });
+
+    describe('formatScmUrl', () => {
+        it('throws an error', () => {
+            assert.throws(() => instance.formatScmUrl('foo'), 'formatScmUrl not implemented');
+        });
+    });
+
+    describe('getPermissons', () => {
+        it('returns error when invalid config object', () => instance.getPermissions({})
+            .then(() => {
+                assert(false, 'you will never get dis');
+            })
+            .catch(err => {
+                assert.isOk(err, 'Error should be returned');
+                assert.equal(err.name, 'ValidationError');
+            })
+        );
+
+        it('returns not implemented', () => {
+            const config = {
+                scmUrl: 'foo',
+                user: 'bar',
+                token: 'token'
+            };
+
+            instance.getPermissions(config)
+              .then(() => {
+                  assert(false, 'you will never get dis');
+              })
+              .catch(err => {
+                  assert.isOk(err, 'Error should be returned');
+                  assert.equal(err.message, 'not implemented');
+              });
+        });
+    });
+
+    describe('getCommitSha', () => {
+        it('returns error when invalid config object', () => instance.getCommitSha({})
+            .then(() => {
+                assert(false, 'you will never get dis');
+            })
+            .catch(err => {
+                assert.isOk(err, 'Error should be returned');
+                assert.equal(err.name, 'ValidationError');
+            })
+        );
+
+        it('returns not implemented', () => {
+            const config = {
+                scmUrl: 'foo',
+                token: 'token'
+            };
+
+            instance.getCommitSha(config)
+              .then(() => {
+                  assert(false, 'you will never get dis');
+              })
+              .catch(err => {
+                  assert.isOk(err, 'Error should be returned');
+                  assert.equal(err.message, 'not implemented');
+              });
+        });
+    });
+
+    describe('updateCommitStatus', () => {
+        it('returns error when invalid config object', () => instance.updateCommitStatus({})
+            .then(() => {
+                assert(false, 'you will never get dis');
+            })
+            .catch(err => {
+                assert.isOk(err, 'Error should be returned');
+                assert.equal(err.name, 'ValidationError');
+            })
+        );
+
+        it('returns not implemented', () => {
+            const config = {
+                scmUrl: 'foo',
+                sha: 'sha1',
+                buildStatus: 'stating',
+                token: 'token'
+            };
+
+            instance.updateCommitStatus(config)
+              .then(() => {
+                  assert(false, 'you will never get dis');
+              })
+              .catch(err => {
+                  assert.isOk(err, 'Error should be returned');
+                  assert.equal(err.message, 'not implemented');
+              });
+        });
     });
 });


### PR DESCRIPTION
This is an initial stab at adding an base implementation for our interactions with source control.

The functions I wrote in this base class come from the different functions that we already call throughout the models. They include:
1.  Getting the commit sha : https://github.com/screwdriver-cd/models/blob/master/lib/buildFactory.js#L51-L56
2. Updating SCM status: https://github.com/screwdriver-cd/models/blob/master/lib/build.js#L22-L32
3. Getting repo permissions: https://github.com/screwdriver-cd/models/blob/master/lib/user.js#L57-L64

These are just what we are calling right now and is definitely not final.

This PR also does not read the schema's from the `screwdriver-data-schema` like it should. I wanted to spike out the initial functions first.

As a discussion, what other functions will we need to have in the scm-base? 