### PR TITLE
Add a new interface for getRepoId

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,13 +134,32 @@ class ScmBase {
 
     /**
      * Return a unique identifier for the scmUrl
-     * @method getId
-     * @param {Object}    config        Configuration
-     * @param {String}    config.scmUrl The scmUrl to generate ID
-     * @param {String}    config.token  The token used to authenticate to the SCM
+     * @method getRepoId
+     * @param  {Object}    config        Configuration
+     * @param  {String}    config.scmUrl The scmUrl to generate ID
+     * @param  {String}    config.token  The token used to authenticate to the SCM
+     * @return {Promise}
      */
-    getId() {
-        throw new Error('getId not implemented');
+    getRepoId(config) {
+        const result = Joi.validate(config, dataSchema.plugins.scm.getRepoId);
+
+        if (result.error) {
+            return Promise.reject(result.error);
+        }
+
+        return this._getRepoId().then((repo) => {
+            const outputResult = Joi.validate(repo, dataSchema.core.scm.repo);
+
+            if (outputResult.error) {
+                return Promise.reject(outputResult.error);
+            }
+
+            return Promise.resolve(repo);
+        });
+    }
+
+    _getRepoId() {
+        return Promise.reject('Not implemented');
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -131,6 +131,17 @@ class ScmBase {
     stats() {
         return {};
     }
+
+    /**
+     * Return a unique identifier for the scmUrl
+     * @method getId
+     * @param {Object}    config        Configuration
+     * @param {String}    config.scmUrl The scmUrl to generate ID
+     * @param {String}    config.token  The token used to authenticate to the SCM
+     */
+    getId() {
+        throw new Error('getId not implemented');
+    }
 }
 
 module.exports = ScmBase;

--- a/index.js
+++ b/index.js
@@ -3,6 +3,23 @@
 const Joi = require('joi');
 const dataSchema = require('screwdriver-data-schema');
 
+/**
+ * Validate the config using the schema
+ * @method  validate
+ * @param  {Object}    config       Configuration
+ * @param  {Object}    schema       Joi object used for validation
+ * @return {Promise}
+ */
+function validate(config, schema) {
+    const result = Joi.validate(config, schema);
+
+    if (result.error) {
+        return Promise.reject(result.error);
+    }
+
+    return Promise.resolve(config);
+}
+
 class ScmBase {
     /**
      * Constructor for Scm
@@ -41,13 +58,8 @@ class ScmBase {
      * @return {Promise}
      */
     getPermissions(config) {
-        const result = Joi.validate(config, dataSchema.plugins.scm.getPermissions);
-
-        if (result.error) {
-            return Promise.reject(result.error);
-        }
-
-        return this._getPermissions(config);
+        return validate(config, dataSchema.plugins.scm.getPermissions)
+            .then(validConfig => this._getPermissions(validConfig));
     }
 
     _getPermissions() {
@@ -63,13 +75,8 @@ class ScmBase {
      * @return {Promise}
      */
     getCommitSha(config) {
-        const result = Joi.validate(config, dataSchema.plugins.scm.getCommitSha);
-
-        if (result.error) {
-            return Promise.reject(result.error);
-        }
-
-        return this._getCommitSha(config);
+        return validate(config, dataSchema.plugins.scm.getCommitSha)
+            .then(validConfig => this._getCommitSha(validConfig));
     }
 
     _getCommitSha() {
@@ -78,7 +85,7 @@ class ScmBase {
 
     /**
      * Update the commit status for a given repo and sha
-     * @method get
+     * @method updateCommitStatus
      * @param  {Object}   config              Configuration
      * @param  {String}   config.scmUrl       The scmUrl to get permissions on
      * @param  {String}   config.sha          The sha to apply the status to
@@ -87,13 +94,8 @@ class ScmBase {
      * @return {Promise}
      */
     updateCommitStatus(config) {
-        const result = Joi.validate(config, dataSchema.plugins.scm.updateCommitStatus);
-
-        if (result.error) {
-            return Promise.reject(result.error);
-        }
-
-        return this._updateCommitStatus(config);
+        return validate(config, dataSchema.plugins.scm.updateCommitStatus)
+            .then(validConfig => this._updateCommitStatus(validConfig));
     }
 
     _updateCommitStatus() {
@@ -110,13 +112,8 @@ class ScmBase {
     * @return {Promise}
     */
     getFile(config) {
-        const result = Joi.validate(config, dataSchema.plugins.scm.getFile);
-
-        if (result.error) {
-            return Promise.reject(result.error);
-        }
-
-        return this._getFile(config);
+        return validate(config, dataSchema.plugins.scm.getFile)
+            .then(validConfig => this._getFile(validConfig));
     }
 
     _getFile() {
@@ -141,21 +138,9 @@ class ScmBase {
      * @return {Promise}
      */
     getRepoId(config) {
-        const result = Joi.validate(config, dataSchema.plugins.scm.getRepoId);
-
-        if (result.error) {
-            return Promise.reject(result.error);
-        }
-
-        return this._getRepoId().then((repo) => {
-            const outputResult = Joi.validate(repo, dataSchema.core.scm.repo);
-
-            if (outputResult.error) {
-                return Promise.reject(outputResult.error);
-            }
-
-            return Promise.resolve(repo);
-        });
+        return validate(config, dataSchema.plugins.scm.getRepoId)
+            .then(validConfig => this._getRepoId(validConfig))
+            .then(repo => validate(repo, dataSchema.core.scm.repo));
     }
 
     _getRepoId() {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
   },
   "dependencies": {
     "joi": "^9.0.4",
-    "screwdriver-data-schema": "^10.0.0"
+    "screwdriver-data-schema": "^11.0.0"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -197,4 +197,11 @@ describe('index test', () => {
               });
         });
     });
+
+    describe('getId', () => {
+        it('throws an error', () => {
+            assert.throws(() =>
+                instance.getId('git@github.com:foo/bar.git'), 'getId not implemented');
+        });
+    });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -38,6 +38,19 @@ describe('index test', () => {
                         scmUrl: Joi.string().required(),
                         token: Joi.string().required(),
                         path: Joi.string().required()
+                    }).required(),
+                    getRepoId: Joi.object().keys({
+                        scmUrl: Joi.string().required(),
+                        token: Joi.string().required()
+                    }).required()
+                }
+            },
+            core: {
+                scm: {
+                    repo: Joi.object().keys({
+                        id: Joi.string().required(),
+                        name: Joi.string().required(),
+                        url: Joi.string().required()
                     }).required()
                 }
             }
@@ -198,10 +211,51 @@ describe('index test', () => {
         });
     });
 
-    describe('getId', () => {
-        it('throws an error', () => {
-            assert.throws(() =>
-                instance.getId('git@github.com:foo/bar.git'), 'getId not implemented');
+    describe('getRepoId', () => {
+        it('returns error when invalid config object', () => instance.getRepoId({})
+            .then(() => {
+                assert.fail('you will never get dis');
+            })
+            .catch(err => {
+                assert.instanceOf(err, Error);
+                assert.equal(err.name, 'ValidationError');
+            })
+        );
+
+        it('returns error when invalid output', () => {
+            const config = {
+                scmUrl: 'foo',
+                token: 'token'
+            };
+
+            instance._getRepoId = () => Promise.resolve({
+                invalid: 'object'
+            });
+
+            instance.getRepoId(config)
+                .then(() => {
+                    assert.fail('you will never get dis');
+                })
+                .catch(err => {
+                    assert.instanceOf(err, Error);
+                    assert.equal(err.name, 'ValidationError');
+                });
+        });
+
+        it('returns not implemented', () => {
+            const config = {
+                scmUrl: 'foo',
+                token: 'token'
+            };
+
+            instance.getRepoId(config)
+                .then(() => {
+                    assert.fail('you will never get dis');
+                })
+                .catch(err => {
+                    assert.instanceOf(err, Error);
+                    assert.equal(err.message, 'Not implemented');
+                });
         });
     });
 });


### PR DESCRIPTION
I added `getId` base function for screwdriver-cd/screwdriver#160 .
An actual process will be implemented in scm-github.