### PR TITLE
Refactor base scm functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 'use strict';
+
 /* eslint-disable no-underscore-dangle */
 const Joi = require('joi');
 const dataSchema = require('screwdriver-data-schema');
@@ -41,19 +42,100 @@ class ScmBase {
     }
 
     /**
-     * Format the scmUrl for the specific source control
-     * @method formatScmUrl
-     * @param {String}    scmUrl        Scm Url to format properly
+     * Parse the url for a repo for the specific source control
+     * @method parseurl
+     * @param  {Object}    config
+     * @param  {String}    config.checkoutUrl       Url to parse
+     * @param  {String}    config.token             The token used to authenticate to the SCM
+     * @return {Promise}
      */
-    formatScmUrl() {
-        throw new Error('formatScmUrl not implemented');
+    parseUrl(config) {
+        return validate(config, dataSchema.plugins.scm.parseUrl)
+            .then(validUrl => this._parseUrl(validUrl))
+            .then(uri => validate(uri, dataSchema.models.pipeline.base.scmUri));
+    }
+
+    _parseUrl() {
+        return Promise.reject('Not implemented');
+    }
+
+    /**
+     * Parse the webhook for the specific source control
+     * @method parseHook
+     * @param  {Object}     headers     The request headers associated with the webhook payload
+     * @param  {Object}     payload     The webhook payload received from the SCM service
+     * @return {Object}                 A key-map of data related to the received payload
+     */
+    parseHook(headers, payload) {
+        const result = this._parseHook(headers, payload);
+
+        return validate(result, dataSchema.core.scm.hook);
+    }
+
+    _parseHook() {
+        throw new Error('Not implemented');
+    }
+
+    /**
+     * Decorate the url for the specific source control
+     * @method decorateUrl
+     * @param  {Object}    config
+     * @param  {String}    config.scmUri       SCM uri to decorate
+     * @param  {String}    config.token        The token used to authenticate to the SCM
+     * @return {Promise}
+     */
+    decorateUrl(config) {
+        return validate(config, dataSchema.plugins.scm.decorateUrl)
+            .then(validUrl => this._decorateUrl(validUrl))
+            .then(decoratedUrl => validate(decoratedUrl, dataSchema.core.scm.repo));
+    }
+
+    _decorateUrl() {
+        return Promise.reject('Not implemented');
+    }
+
+    /**
+     * Decorate the commit for the specific source control
+     * @method decorateCommit
+     * @param  {Object}    config
+     * @param  {String}    config.sha           Commit sha to decorate
+     * @param  {String}    config.scmUri        SCM uri
+     * @param  {String}    config.token         The token used to authenticate to the SCM
+     * @return {Promise}
+     */
+    decorateCommit(config) {
+        return validate(config, dataSchema.plugins.scm.decorateCommit)
+            .then(validCommit => this._decorateCommit(validCommit))
+            .then(decoratedCommit => validate(decoratedCommit, dataSchema.core.scm.commit));
+    }
+
+    _decorateCommit() {
+        return Promise.reject('Not implemented');
+    }
+
+    /**
+     * Decorate the author for the specific source control
+     * @method decorateAuthor
+     * @param  {Object}    config
+     * @param  {String}    config.username  Author to decorate
+     * @param  {String}    config.token     The token used to authenticate to the SCM
+     * @return {Promise}
+     */
+    decorateAuthor(config) {
+        return validate(config, dataSchema.plugins.scm.decorateAuthor)
+            .then(validAuthor => this._decorateAuthor(validAuthor))
+            .then(decoratedAuthor => validate(decoratedAuthor, dataSchema.core.scm.user));
+    }
+
+    _decorateAuthor() {
+        return Promise.reject('Not implemented');
     }
 
     /**
      * Get a users permissions on a repository
      * @method getPermissions
      * @param  {Object}   config            Configuration
-     * @param  {String}   config.scmUrl     The scmUrl to get permissions on
+     * @param  {String}   config.scmUri     The scmUri to get permissions on
      * @param  {String}   config.token      The token used to authenticate to the SCM
      * @return {Promise}
      */
@@ -70,7 +152,7 @@ class ScmBase {
      * Get a commit sha for a specific repo#branch
      * @method getCommitSha
      * @param  {Object}   config            Configuration
-     * @param  {String}   config.scmUrl     The scmUrl to get commit sha of
+     * @param  {String}   config.scmUri     The scmUri to get commit sha of
      * @param  {String}   config.token      The token used to authenticate to the SCM
      * @return {Promise}
      */
@@ -87,7 +169,7 @@ class ScmBase {
      * Update the commit status for a given repo and sha
      * @method updateCommitStatus
      * @param  {Object}   config              Configuration
-     * @param  {String}   config.scmUrl       The scmUrl to get permissions on
+     * @param  {String}   config.scmUri       The scmUri to get permissions on
      * @param  {String}   config.sha          The sha to apply the status to
      * @param  {String}   config.buildStatus  The build status used for figuring out the commit status to set
      * @param  {String}   config.token        The token used to authenticate to the SCM
@@ -108,7 +190,7 @@ class ScmBase {
     * Fetch content of a file from an scm repo
     * @method getFile
     * @param  {Object}   config              Configuration
-    * @param  {String}   config.scmUrl       The scmUrl to get permissions on
+    * @param  {String}   config.scmUri       The scmUri to get permissions on
     * @param  {String}   config.path         The file in the repo to fetch
     * @param  {String}   config.token        The token used to authenticate to the SCM
     * @return {Promise}
@@ -129,24 +211,6 @@ class ScmBase {
      */
     stats() {
         return {};
-    }
-
-    /**
-     * Return a unique identifier for the scmUrl
-     * @method getRepoId
-     * @param  {Object}    config        Configuration
-     * @param  {String}    config.scmUrl The scmUrl to generate ID
-     * @param  {String}    config.token  The token used to authenticate to the SCM
-     * @return {Promise}
-     */
-    getRepoId(config) {
-        return validate(config, dataSchema.plugins.scm.getRepoId)
-            .then(validConfig => this._getRepoId(validConfig))
-            .then(repo => validate(repo, dataSchema.core.scm.repo));
-    }
-
-    _getRepoId() {
-        return Promise.reject('Not implemented');
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-scm-base",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Base class for defining the behavior between screwdriver and source control management systems",
   "main": "index.js",
   "scripts": {
@@ -32,13 +32,13 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "eslint": "^3.2.2",
-    "eslint-config-screwdriver": "^2.0.0",
+    "eslint-config-screwdriver": "^2.0.5",
     "eslint-plugin-import": "^1.12.0",
-    "jenkins-mocha": "^2.6.0",
-    "mockery": "^1.7.0"
+    "jenkins-mocha": "^3.0.4",
+    "mockery": "^2.0.0"
   },
   "dependencies": {
     "joi": "^9.0.4",
-    "screwdriver-data-schema": "^13.0.0"
+    "screwdriver-data-schema": "^14.0.0"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,4 +1,5 @@
 'use strict';
+
 /* eslint-disable no-underscore-dangle */
 const assert = require('chai').assert;
 const mockery = require('mockery');
@@ -21,26 +22,39 @@ describe('index test', () => {
             plugins: {
                 scm: {
                     getPermissions: Joi.object().keys({
-                        scmUrl: Joi.string().required(),
+                        scmUri: Joi.string().required(),
                         token: Joi.string().required()
                     }).required(),
                     getCommitSha: Joi.object().keys({
-                        scmUrl: Joi.string().required(),
+                        scmUri: Joi.string().required(),
                         token: Joi.string().required()
                     }).required(),
                     updateCommitStatus: Joi.object().keys({
-                        scmUrl: Joi.string().required(),
+                        scmUri: Joi.string().required(),
                         token: Joi.string().required(),
                         buildStatus: Joi.string().required(),
                         sha: Joi.string().required()
                     }).required(),
                     getFile: Joi.object().keys({
-                        scmUrl: Joi.string().required(),
+                        scmUri: Joi.string().required(),
                         token: Joi.string().required(),
                         path: Joi.string().required()
                     }).required(),
-                    getRepoId: Joi.object().keys({
-                        scmUrl: Joi.string().required(),
+                    parseUrl: Joi.object().keys({
+                        checkoutUrl: Joi.string().required(),
+                        token: Joi.string().required()
+                    }).required(),
+                    decorateUrl: Joi.object().keys({
+                        scmUri: Joi.string().required(),
+                        token: Joi.string().required()
+                    }).required(),
+                    decorateCommit: Joi.object().keys({
+                        sha: Joi.string().required(),
+                        scmUri: Joi.string().required(),
+                        token: Joi.string().required()
+                    }).required(),
+                    decorateAuthor: Joi.object().keys({
+                        username: Joi.string().required(),
                         token: Joi.string().required()
                     }).required()
                 }
@@ -48,9 +62,37 @@ describe('index test', () => {
             core: {
                 scm: {
                     repo: Joi.object().keys({
-                        id: Joi.string().required(),
                         name: Joi.string().required(),
+                        branch: Joi.string().required(),
                         url: Joi.string().required()
+                    }).required(),
+                    commit: Joi.object().keys({
+                        username: Joi.string().required(),
+                        message: Joi.string().required(),
+                        url: Joi.string().required()
+                    }).required(),
+                    user: Joi.object().keys({
+                        name: Joi.string().required(),
+                        username: Joi.string().required(),
+                        avatar: Joi.string().required(),
+                        url: Joi.string().required()
+                    }).required(),
+                    hook: Joi.object().keys({
+                        type: Joi.string().required(),
+                        action: Joi.string().required(),
+                        prNum: Joi.number().optional(),
+                        checkoutUrl: Joi.string().required(),
+                        branch: Joi.string().required(),
+                        prRef: Joi.string().optional(),
+                        sha: Joi.string().required(),
+                        username: Joi.string().required()
+                    }).required()
+                }
+            },
+            models: {
+                pipeline: {
+                    base: Joi.object().keys({
+                        scmUri: Joi.string().required()
                     }).required()
                 }
             }
@@ -84,96 +126,326 @@ describe('index test', () => {
         });
     });
 
-    describe('formatScmUrl', () => {
-        it('throws an error', () => {
-            assert.throws(() => instance.formatScmUrl('foo'), 'formatScmUrl not implemented');
+    describe('parseUrl', () => {
+        const config = {
+            checkoutUrl: 'foo',
+            token: 'bar'
+        };
+
+        it('returns error when invalid config object', () => instance.parseUrl({})
+            .then(() => {
+                assert.fail('you will never get dis');
+            })
+            .catch((err) => {
+                assert.instanceOf(err, Error);
+                assert.equal(err.name, 'ValidationError');
+            })
+        );
+
+        it('returns error when invalid output', () => {
+            instance._parseUrl = () => Promise.resolve({
+                invalid: 'object'
+            });
+
+            return instance.parseUrl(config)
+                .then(() => {
+                    assert.fail('you will never get dis');
+                })
+                .catch((err) => {
+                    assert.instanceOf(err, Error);
+                    assert.equal(err.name, 'Error');
+                });
+        });
+
+        it('returns not implemented', () => instance.parseUrl(config)
+                .then(() => {
+                    assert.fail('you will never get dis');
+                })
+                .catch((err) => {
+                    assert.equal(err, 'Not implemented');
+                })
+        );
+    });
+
+    describe('parseHook', () => {
+        const headers = {
+            stuff: 'foo'
+        };
+        const payload = {
+            moreStuff: 'bar'
+        };
+
+        it('returns error when invalid output', () => {
+            instance._parseHook = () => {
+                const result = {
+                    invalid: 'object'
+                };
+
+                return result;
+            };
+
+            instance.parseHook(headers, payload)
+                .then(() => {
+                    assert.fail('you will never get dis');
+                })
+                .catch((err) => {
+                    assert.instanceOf(err, Error);
+                    assert.equal(err.name, 'ValidationError');
+                });
+        });
+
+        it('returns not implemented', () => {
+            assert.throws(() => instance.parseHook(headers, payload), 'Not implemented');
         });
     });
 
+    describe('decorateUrl', () => {
+        const config = {
+            scmUri: 'foo',
+            token: 'token'
+        };
+
+        it('returns error when invalid config object', () => instance.decorateUrl({})
+            .then(() => {
+                assert.fail('you will never get dis');
+            })
+            .catch((err) => {
+                assert.instanceOf(err, Error);
+                assert.equal(err.name, 'ValidationError');
+            })
+        );
+
+        it('returns error when invalid output', () => {
+            instance._decorateUrl = () => Promise.resolve({
+                invalid: 'object'
+            });
+
+            return instance.decorateUrl(config)
+                .then(() => {
+                    assert.fail('you will never get dis');
+                })
+                .catch((err) => {
+                    assert.instanceOf(err, Error);
+                    assert.equal(err.name, 'ValidationError');
+                });
+        });
+
+        it('returns not implemented', () => instance.decorateUrl(config)
+                .then(() => {
+                    assert.fail('you will never get dis');
+                })
+                .catch((err) => {
+                    assert.equal(err, 'Not implemented');
+                })
+        );
+    });
+
+    describe('decorateCommit', () => {
+        const config = {
+            sha: '123abc',
+            scmUri: 'foo',
+            token: 'token'
+        };
+
+        it('returns error when invalid config object', () => instance.decorateCommit({})
+            .then(() => {
+                assert.fail('you will never get dis');
+            })
+            .catch((err) => {
+                assert.instanceOf(err, Error);
+                assert.equal(err.name, 'ValidationError');
+            })
+        );
+
+        it('returns error when invalid output', () => {
+            instance._decorateCommit = () => Promise.resolve({
+                invalid: 'object'
+            });
+
+            return instance.decorateCommit(config)
+                .then(() => {
+                    assert.fail('you will never get dis');
+                })
+                .catch((err) => {
+                    assert.instanceOf(err, Error);
+                    assert.equal(err.name, 'ValidationError');
+                });
+        });
+
+        it('returns not implemented', () => instance.decorateCommit(config)
+                .then(() => {
+                    assert.fail('you will never get dis');
+                })
+                .catch((err) => {
+                    assert.equal(err, 'Not implemented');
+                })
+        );
+    });
+
+    describe('decorateAuthor', () => {
+        const config = {
+            username: 'd2lam',
+            token: 'token'
+        };
+
+        it('returns error when invalid config object', () => instance.decorateAuthor({})
+            .then(() => {
+                assert.fail('you will never get dis');
+            })
+            .catch((err) => {
+                assert.instanceOf(err, Error);
+                assert.equal(err.name, 'ValidationError');
+            })
+        );
+
+        it('returns error when invalid output', () => {
+            instance._decorateAuthor = () => Promise.resolve({
+                invalid: 'object'
+            });
+
+            return instance.decorateAuthor(config)
+                .then(() => {
+                    assert.fail('you will never get dis');
+                })
+                .catch((err) => {
+                    assert.instanceOf(err, Error);
+                    assert.equal(err.name, 'ValidationError');
+                });
+        });
+
+        it('returns not implemented', () => instance.decorateAuthor(config)
+                .then(() => {
+                    assert.fail('you will never get dis');
+                })
+                .catch((err) => {
+                    assert.equal(err, 'Not implemented');
+                })
+        );
+    });
+
     describe('getPermissons', () => {
+        const config = {
+            scmUri: 'foo',
+            token: 'token'
+        };
+
         it('returns error when invalid config object', () => instance.getPermissions({})
             .then(() => {
                 assert.fail('you will never get dis');
             })
-            .catch(err => {
+            .catch((err) => {
                 assert.instanceOf(err, Error);
                 assert.equal(err.name, 'ValidationError');
             })
         );
 
-        it('returns not implemented', () => {
-            const config = {
-                scmUrl: 'foo',
-                token: 'token'
-            };
+        it('returns error when invalid output', () => {
+            instance._getPermissions = () => Promise.resolve({
+                invalid: 'object'
+            });
 
-            instance.getPermissions(config)
-              .then(() => {
-                  assert.fail('you will never get dis');
-              })
-              .catch(err => {
-                  assert.instanceOf(err, Error);
-                  assert.equal(err.message, 'not implemented');
-              });
+            return instance.getPermissions(config)
+                .then(() => {
+                    assert.fail('you will never get dis');
+                })
+                .catch((err) => {
+                    assert.instanceOf(err, Error);
+                    assert.equal(err.name, 'AssertionError');
+                });
         });
+
+        it('returns not implemented', () => instance.getPermissions(config)
+                .then(() => {
+                    assert.fail('you will never get dis');
+                })
+                .catch((err) => {
+                    assert.equal(err, 'Not implemented');
+                })
+        );
     });
 
     describe('getCommitSha', () => {
+        const config = {
+            scmUri: 'foo',
+            token: 'token'
+        };
+
         it('returns error when invalid config object', () => instance.getCommitSha({})
             .then(() => {
                 assert.fail('you will never get dis');
             })
-            .catch(err => {
+            .catch((err) => {
                 assert.instanceOf(err, Error);
                 assert.equal(err.name, 'ValidationError');
             })
         );
 
-        it('returns not implemented', () => {
-            const config = {
-                scmUrl: 'foo',
-                token: 'token'
-            };
+        it('returns error when invalid output', () => {
+            instance._getCommitSha = () => Promise.resolve({
+                invalid: 'object'
+            });
 
-            instance.getCommitSha(config)
-              .then(() => {
-                  assert.fail('you will never get dis');
-              })
-              .catch(err => {
-                  assert.instanceOf(err, Error);
-                  assert.equal(err.message, 'not implemented');
-              });
+            return instance.getCommitSha(config)
+                .then(() => {
+                    assert.fail('you will never get dis');
+                })
+                .catch((err) => {
+                    assert.instanceOf(err, Error);
+                    assert.equal(err.name, 'AssertionError');
+                });
         });
+
+        it('returns not implemented', () => instance.getCommitSha(config)
+                .then(() => {
+                    assert.fail('you will never get dis');
+                })
+                .catch((err) => {
+                    assert.equal(err, 'Not implemented');
+                })
+        );
     });
 
     describe('updateCommitStatus', () => {
+        const config = {
+            scmUri: 'foo',
+            sha: 'sha1',
+            buildStatus: 'stating',
+            token: 'token'
+        };
+
         it('returns error when invalid config object', () => instance.updateCommitStatus({})
             .then(() => {
                 assert.fail('you will never get dis');
             })
-            .catch(err => {
+            .catch((err) => {
                 assert.instanceOf(err, Error);
                 assert.equal(err.name, 'ValidationError');
             })
         );
 
-        it('returns not implemented', () => {
-            const config = {
-                scmUrl: 'foo',
-                sha: 'sha1',
-                buildStatus: 'stating',
-                token: 'token'
-            };
+        it('returns error when invalid output', () => {
+            instance._updateCommitStatus = () => Promise.resolve({
+                invalid: 'object'
+            });
 
-            instance.updateCommitStatus(config)
-              .then(() => {
-                  assert.fail('you will never get dis');
-              })
-              .catch(err => {
-                  assert.instanceOf(err, Error);
-                  assert.equal(err.message, 'not implemented');
-              });
+            return instance.updateCommitStatus(config)
+                .then(() => {
+                    assert.fail('you will never get dis');
+                })
+                .catch((err) => {
+                    assert.instanceOf(err, Error);
+                    assert.equal(err.name, 'AssertionError');
+                });
         });
+
+        it('returns not implemented', () => instance.updateCommitStatus(config)
+                .then(() => {
+                    assert.fail('you will never get dis');
+                })
+                .catch((err) => {
+                    assert.equal(err, 'Not implemented');
+                })
+        );
     });
 
     describe('stats', () => {
@@ -183,79 +455,44 @@ describe('index test', () => {
     });
 
     describe('getFile', () => {
+        const config = {
+            scmUri: 'foo',
+            path: 'testFile',
+            token: 'token'
+        };
+
         it('returns error when invalid config object', () => instance.getFile({})
             .then(() => {
                 assert.fail('you will never get dis');
             })
-            .catch(err => {
-                assert.instanceOf(err, Error);
-                assert.equal(err.name, 'ValidationError');
-            })
-        );
-
-        it('returns not implemented', () => {
-            const config = {
-                scmUrl: 'foo',
-                path: 'testFile',
-                token: 'token'
-            };
-
-            instance.getFile(config)
-              .then(() => {
-                  assert.fail('you will never get dis');
-              })
-              .catch(err => {
-                  assert.instanceOf(err, Error);
-                  assert.equal(err.message, 'not implemented');
-              });
-        });
-    });
-
-    describe('getRepoId', () => {
-        it('returns error when invalid config object', () => instance.getRepoId({})
-            .then(() => {
-                assert.fail('you will never get dis');
-            })
-            .catch(err => {
+            .catch((err) => {
                 assert.instanceOf(err, Error);
                 assert.equal(err.name, 'ValidationError');
             })
         );
 
         it('returns error when invalid output', () => {
-            const config = {
-                scmUrl: 'foo',
-                token: 'token'
-            };
-
-            instance._getRepoId = () => Promise.resolve({
+            instance._getFile = () => Promise.resolve({
                 invalid: 'object'
             });
 
-            instance.getRepoId(config)
+            return instance.getFile(config)
                 .then(() => {
                     assert.fail('you will never get dis');
                 })
-                .catch(err => {
+                .catch((err) => {
                     assert.instanceOf(err, Error);
-                    assert.equal(err.name, 'ValidationError');
+                    assert.equal(err.name, 'AssertionError');
                 });
         });
 
-        it('returns not implemented', () => {
-            const config = {
-                scmUrl: 'foo',
-                token: 'token'
-            };
-
-            instance.getRepoId(config)
+        it('returns not implemented', () => instance.getFile(config)
                 .then(() => {
                     assert.fail('you will never get dis');
                 })
-                .catch(err => {
-                    assert.instanceOf(err, Error);
-                    assert.equal(err.message, 'Not implemented');
-                });
-        });
+                .catch((err) => {
+                    assert.equal(err, 'Not implemented');
+                })
+        );
     });
 });


### PR DESCRIPTION
In preparation for creating a Bitbucket scm plugin, refactoring some functions in the scm base class:
- Add decorators for url, commit, and author
- Add parsers for url and hook
- Deprecate `scmUrl` in favor of `scmUri` (`github.com:12345:master`)

Blocked by https://github.com/screwdriver-cd/data-schema/pull/67
Related to https://github.com/screwdriver-cd/screwdriver/issues/255