### PR TITLE
Needs to do joi.reach for scmUri

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ class ScmBase {
     parseUrl(config) {
         return validate(config, dataSchema.plugins.scm.parseUrl)
             .then(validUrl => this._parseUrl(validUrl))
-            .then(uri => validate(uri, dataSchema.models.pipeline.base.scmUri));
+            .then(uri => validate(uri, Joi.reach(dataSchema.models.pipeline.base, 'scmUri')));
     }
 
     _parseUrl() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -9,6 +9,12 @@ describe('index test', () => {
     let instance;
     let ScmBase;
     let schemaMock;
+    const MODEL = {
+        scmUri: Joi
+            .string().regex(/^([^:]+):([\w-]+):(.+)$/)
+            .description('Unique identifier for the application')
+            .example('github.com:123456:master')
+    };
 
     before(() => {
         mockery.enable({
@@ -91,9 +97,7 @@ describe('index test', () => {
             },
             models: {
                 pipeline: {
-                    base: Joi.object().keys({
-                        scmUri: Joi.string().required()
-                    }).required()
+                    base: Joi.object(MODEL)
                 }
             }
         };


### PR DESCRIPTION
We cannot hit `dataSchema.models.pipeline.base.scmUri` directly