### PR TITLE
Promisify errors from parseHook

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,13 @@ class ScmBase {
      * @return {Promise}
      */
     parseHook(headers, payload) {
-        const result = this._parseHook(headers, payload);
+        let result;
+
+        try {
+            result = this._parseHook(headers, payload);
+        } catch (err) {
+            return Promise.reject(err);
+        }
 
         return validate(result, dataSchema.core.scm.hook);
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -198,9 +198,14 @@ describe('index test', () => {
                 });
         });
 
-        it('returns not implemented', () => {
-            assert.throws(() => instance.parseHook(headers, payload), 'Not implemented');
-        });
+        it('returns not implemented', () =>
+            instance.parseHook(headers, payload)
+            .then(() => {
+                assert.fail('This should not fail the test');
+            }, (err) => {
+                assert.strictEqual(err.message, 'Not implemented');
+            })
+        );
     });
 
     describe('decorateUrl', () => {


### PR DESCRIPTION
Since the inner `_parseHook` can throw an error in some cases, the `parseHook` method should catch those. This change is to ensure those errors are caught and a Promise is rejected when `_parseHook` fails.