### PR TITLE
targetUrl was missing in commitstatus

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -333,7 +333,8 @@ describe('index test', () => {
             scmUri: 'github.com:repoId:branch',
             sha: '0264b13de9aa293b7abc8cf36793b6458c07af38',
             buildStatus: 'SUCCESS',
-            token: 'token'
+            token: 'token',
+            url: 'https://foo.bar'
         };
 
         it('returns error when invalid config object', () => instance.updateCommitStatus({})


### PR DESCRIPTION
This passed in the PR build because https://github.com/screwdriver-cd/screwdriver/issues/285 was not merged yet. Now the master branch build is failing because target url is missing. 