### PR TITLE
[2] Revert "Use new getFile validation if PR ref is passed in"

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,11 +198,10 @@ The parameters required are:
 | Parameter        | Type  | Required | Description |
 | :-------------   | :---- | :------- | :-------------|
 | config        | Object | true | Configuration Object |
-| config.scmUri | String | false | The scm uri (ex: `github.com:1234:branchName`) |
+| config.scmUri | String | true | The scm uri (ex: `github.com:1234:branchName`) |
 | config.token | String | true | Access token for scm |
 | config.path | String | true | The path to the file on scm to read |
 | config.ref | String | false | The reference to the scm repo, could be a branch or sha |
-Note: either `ref` or `scmUri` is required.
 
 #### Expected Outcome
 The contents of the file at `path` in the repository

--- a/index.js
+++ b/index.js
@@ -197,18 +197,12 @@ class ScmBase {
     * Fetch content of a file from an scm repo
     * @method getFile
     * @param  {Object}   config              Configuration
+    * @param  {String}   config.scmUri       The scmUri to get permissions on
     * @param  {String}   config.path         The file in the repo to fetch
-    * @param  {String}   [config.ref]        The reference to the SCM, either branch or sha
-    * @param  {String}   [config.scmUri]     The scmUri to get permissions on
     * @param  {String}   config.token        The token used to authenticate to the SCM
     * @return {Promise}
     */
     getFile(config) {
-        if (config.ref) {
-            return validate(config, dataSchema.plugins.scm.getFileRef)
-                .then(validConfig => this._getFile(validConfig));
-        }
-
         return validate(config, dataSchema.plugins.scm.getFile)
             .then(validConfig => this._getFile(validConfig));
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -410,22 +410,6 @@ describe('index test', () => {
                 });
         });
 
-        it('returns not implemented with valid prRef input', () => {
-            const prConfig = {
-                ref: 'git@github.com:screwdriver-cd-test/functional-git.git#pull/453/merge',
-                path: 'testFile',
-                token: 'token'
-            };
-
-            return instance.getFile(prConfig)
-                .then(() => {
-                    assert.fail('you will never get dis');
-                })
-                .catch((err) => {
-                    assert.equal(err, 'Not implemented');
-                });
-        });
-
         it('returns not implemented', () => instance.getFile(config)
                 .then(() => {
                     assert.fail('you will never get dis');


### PR DESCRIPTION
We will change the API instead to pass in ref, not the whole URL. So there is no need for the getFileRef anymore

Should be merged after https://github.com/screwdriver-cd/models/pull/125