### PR TITLE
Use promise for _parseUrl and remove validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,20 +67,11 @@ class ScmBase {
      * @return {Promise}
      */
     parseHook(headers, payload) {
-        let result;
-
-        try {
-            result = this._parseHook(headers, payload);
-        } catch (err) {
-            return Promise.reject(err);
-        }
-
-        return validate(result, dataSchema.core.scm.hook);
+        return this._parseHook(headers, payload);
     }
 
-    // Should return a key-map of data related to the received payload; not a promise
     _parseHook() {
-        throw new Error('Not implemented');
+        return Promise.reject('Not implemented');
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-scm-base",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Base class for defining the behavior between screwdriver and source control management systems",
   "main": "index.js",
   "scripts": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -93,22 +93,16 @@ describe('index test', () => {
             moreStuff: 'bar'
         };
 
-        it('returns error when invalid output', () => {
-            instance._parseHook = () => {
-                const result = {
-                    invalid: 'object'
-                };
+        it('returns data from underlying method', () => {
+            instance._parseHook = () => Promise.resolve({
+                type: 'pr'
+            });
 
-                return result;
-            };
-
-            instance.parseHook(headers, payload)
-                .then(() => {
-                    assert.fail('you will never get dis');
-                })
-                .catch((err) => {
-                    assert.instanceOf(err, Error);
-                    assert.equal(err.name, 'ValidationError');
+            return instance.parseHook()
+                .then((output) => {
+                    assert.deepEqual(output, {
+                        type: 'pr'
+                    });
                 });
         });
 
@@ -117,7 +111,7 @@ describe('index test', () => {
             .then(() => {
                 assert.fail('This should not fail the test');
             }, (err) => {
-                assert.strictEqual(err.message, 'Not implemented');
+                assert.equal(err, 'Not implemented');
             })
         );
     });


### PR DESCRIPTION
- Use promise for _parseUrl
- Remove validation for resolved results from parseHook