### PR TITLE
Add method to get checkout commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# CHANGELOG
+
+## 2.4.0
+
+Features:
+  * Add method to get checkout commands for scm plugin.

--- a/README.md
+++ b/README.md
@@ -51,13 +51,39 @@ A key-map of data related to the received payload in the form of:
     branch: 'mynewbranch',
     sha: '9ff49b2d1437567cad2b5fed7a0706472131e927',
     prNum: 3,
-    prRef: 'refs/pull-requests/3/from'
+    prRef: 'pull/3/merge'
 }
 ```
 
 #### Expected Promise response
 1. Resolve with a parsed hook object
 2. Reject if not able to parse hook
+
+### getCheckoutCommand
+Required parameters:
+
+| Parameter        | Type  | Required |  Description |
+| :-------------   | :---- | :--------| :---- |
+| config        | Object | Yes | Configuration Object |
+| config.branch | String | Yes | Pipeline branch |
+| config.host | String | Yes | Scm host (ex: github.com) |
+| config.org | String | Yes | Scm org (ex: screwdriver-cd) |
+| config.prRef | String | No | PR branch or reference |
+| config.repo | String | Yes | Scm repo (ex: guide) |
+| config.sha | String | Yes | Scm sha |
+
+#### Expected Outcome
+Checkout command in the form of:
+```js
+{
+    name: 'checkout-code',
+    command: 'git clone https://github.com/screwdriver-cd/guide'
+}
+```
+
+#### Expected Promise response
+1. Resolve with a checkout command object for the repository
+2. Reject if not able to get checkout command
 
 ### decorateUrl
 Required parameters:
@@ -179,13 +205,13 @@ The parameters required are:
 
 | Parameter        | Type  | Required | Description |
 | :-------------   | :---- | :------- | :-------------|
-| config        | Object | true | Configuration Object |
-| config.buildStatus | String | true | The screwdriver build status to translate into scm commit status |
-| config.jobName | String | false | Optional name of the job that finished |
-| config.scmUri | String | true | The scm uri (ex: `github.com:1234:branchName`) |
-| config.sha | String | true | The scm sha to update a status for |
-| config.token | String | true | Access token for scm |
-| config.url | String | false | The target url for setting up details |
+| config        | Object | Yes | Configuration Object |
+| config.buildStatus | String | Yes | The screwdriver build status to translate into scm commit status |
+| config.jobName | String | No | Optional name of the job that finished |
+| config.scmUri | String | Yes | The scm uri (ex: `github.com:1234:branchName`) |
+| config.sha | String | Yes | The scm sha to update a status for |
+| config.token | String | Yes | Access token for scm |
+| config.url | String | No | The target url for setting up details |
 
 #### Expected Outcome
 Update the commit status for a given repository and sha.
@@ -225,6 +251,7 @@ To make use of the validation functions, the functions to override are:
 
 1. `_parseUrl`
 1. `_parseHook`
+1. `_getCheckoutCommand`
 1. `_decorateUrl`
 1. `_decorateCommit`
 1. `_decorateAuthor`

--- a/index.js
+++ b/index.js
@@ -75,6 +75,29 @@ class ScmBase {
     }
 
     /**
+     * Checkout the source code from a repository; resolves as an object with checkout commands
+     * @method getCheckoutCommand
+     * @param  {Object}    config
+     * @param  {String}    config.branch        Pipeline branch
+     * @param  {String}    config.host          Scm host to checkout source code from
+     * @param  {String}    config.org           Scm org name
+     * @param  {String}    config.repo          Scm repo name
+     * @param  {String}    config.sha           Commit sha
+     * @param  {String}    [config.prRef]       PR reference (can be a PR branch or reference)
+     * @return {Promise}
+     */
+    getCheckoutCommand(config) {
+        return validate(config, dataSchema.plugins.scm.getCheckoutCommand)
+            .then(validCheckout => this._getCheckoutCommand(validCheckout))
+            .then(checkoutCommand => validate(checkoutCommand,
+                dataSchema.models.build.getStep));
+    }
+
+    _getCheckoutCommand() {
+        return Promise.reject('Not implemented');
+    }
+
+    /**
      * Decorate the url for the specific source control
      * @method decorateUrl
      * @param  {Object}    config

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-scm-base",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Base class for defining the behavior between screwdriver and source control management systems",
   "main": "index.js",
   "scripts": {
@@ -33,12 +33,11 @@
     "chai": "^3.5.0",
     "eslint": "^3.2.2",
     "eslint-config-screwdriver": "^2.0.5",
-    "eslint-plugin-import": "^1.12.0",
     "jenkins-mocha": "^3.0.4",
     "mockery": "^2.0.0"
   },
   "dependencies": {
     "joi": "^9.1.1",
-    "screwdriver-data-schema": "^15.0.0"
+    "screwdriver-data-schema": "^15.3.0"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -116,6 +116,50 @@ describe('index test', () => {
         );
     });
 
+    describe('getCheckoutCommand', () => {
+        const config = {
+            branch: 'branch',
+            host: 'github.com',
+            org: 'screwdriver-cd',
+            repo: 'guide',
+            sha: '12345'
+        };
+
+        it('returns error when invalid config object', () => instance.getCheckoutCommand({})
+            .then(() => {
+                assert.fail('you will never get dis');
+            })
+            .catch((err) => {
+                assert.instanceOf(err, Error);
+                assert.equal(err.name, 'ValidationError');
+            })
+        );
+
+        it('returns error when invalid output', () => {
+            instance._getCheckoutCommand = () => Promise.resolve({
+                invalid: 'object'
+            });
+
+            return instance.getCheckoutCommand(config)
+                .then(() => {
+                    assert.fail('you will never get dis');
+                })
+                .catch((err) => {
+                    assert.instanceOf(err, Error);
+                    assert.equal(err.name, 'ValidationError');
+                });
+        });
+
+        it('returns not implemented', () => instance.getCheckoutCommand(config)
+                .then(() => {
+                    assert.fail('you will never get dis');
+                })
+                .catch((err) => {
+                    assert.equal(err, 'Not implemented');
+                })
+        );
+    });
+
     describe('decorateUrl', () => {
         const config = {
             scmUri: 'github.com:repoId:branch',


### PR DESCRIPTION
The [launcher](https://github.com/screwdriver-cd/launcher/) is currently hardcoded to checkout repositories from github.com. We want to move that logic into the scm plugins. Adding a method to get checkout commands in the scm-base as an initial step towards that goal.

Relates to https://github.com/screwdriver-cd/screwdriver/issues/312
