### PR TITLE
[2] Checkout command name must be sd-checkout-code

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Required parameters:
 Checkout command in the form of:
 ```js
 {
-    name: 'checkout-code',
+    name: 'sd-checkout-code', // must be 'sd-checkout-code' exactly
     command: 'git clone https://github.com/screwdriver-cd/guide'
 }
 ```

--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ class ScmBase {
         return validate(config, dataSchema.plugins.scm.getCheckoutCommand)
             .then(validCheckout => this._getCheckoutCommand(validCheckout))
             .then(checkoutCommand => validate(checkoutCommand,
-                dataSchema.models.build.getStep));
+                dataSchema.core.scm.command));
     }
 
     _getCheckoutCommand() {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
   },
   "dependencies": {
     "joi": "^9.1.1",
-    "screwdriver-data-schema": "^15.3.0"
+    "screwdriver-data-schema": "^15.4.0"
   }
 }


### PR DESCRIPTION
Use new validation for output of `getCheckoutCommand` method

Blocked by https://github.com/screwdriver-cd/data-schema/pull/94
Related to https://github.com/screwdriver-cd/models/pull/132