### PR TITLE
Add getSetupCommand

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ Checkout command in the form of:
 1. Resolve with a checkout command object for the repository
 2. Reject if not able to get checkout command
 
+### getSetupCommand
+Internally calls getCheckoutCommand to get just the checkout command for a build, given a pipeline model and build configuration.
+
+Required Parameters:
+
+| Parameter        | Type  | Required |  Description |
+| :-------------   | :---- | :--------| :---- |
+| config        | Object | Yes | Configuration Object |
+| config.pipeline | PipelineModel | Yes | Pipeline model |
+| config.build | Object | Yes | build config with sha and possibly prRef |
+
 ### decorateUrl
 Required parameters:
 

--- a/index.js
+++ b/index.js
@@ -98,6 +98,32 @@ class ScmBase {
     }
 
     /**
+     * Gives the commands needed for setup before the build starts
+     * @method getSetupCommand
+     * @param  {Object}         o           Information about the environment for setup
+     * @param  {PipelineModel}  o.pipeline  Pipeline model for the build
+     * @param  {Object}         o.build     Build configuration for the build (before creation)
+     * @return {Promise}
+     */
+    getSetupCommand(o) {
+        const [host, , branch] = o.pipeline.scmUri.split(':');
+        const [org, repo] = o.pipeline.scmRepo.name.split('/');
+        const checkoutConfig = {
+            branch,
+            host,
+            org,
+            repo,
+            sha: o.build.sha
+        };
+
+        if (o.build.prRef) {
+            checkoutConfig.prRef = o.build.prRef;
+        }
+
+        return this.getCheckoutCommand(checkoutConfig).then(c => c.command);
+    }
+
+    /**
      * Decorate the url for the specific source control
      * @method decorateUrl
      * @param  {Object}    config

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -160,6 +160,63 @@ describe('index test', () => {
         );
     });
 
+    describe('getSetupCommand', () => {
+        let config;
+
+        beforeEach(() => {
+            config = {
+                pipeline: {
+                    scmUri: 'github.com:12344567:branch',
+                    scmRepo: { name: 'screwdriver-cd/guide' }
+                },
+                job: {},
+                build: {
+                    sha: '12345'
+                }
+            };
+        });
+
+        it('returns a command', () => {
+            instance._getCheckoutCommand = (o) => {
+                assert.deepEqual(o, {
+                    branch: 'branch',
+                    host: 'github.com',
+                    org: 'screwdriver-cd',
+                    repo: 'guide',
+                    sha: '12345'
+                });
+
+                return Promise.resolve({ name: 'sd-checkout-code', command: 'stuff' });
+            };
+
+            return instance.getSetupCommand(config)
+                .then((command) => {
+                    assert.equal(command, 'stuff');
+                });
+        });
+
+        it('returns a command for pr', () => {
+            instance._getCheckoutCommand = (o) => {
+                assert.deepEqual(o, {
+                    branch: 'branch',
+                    host: 'github.com',
+                    org: 'screwdriver-cd',
+                    repo: 'guide',
+                    sha: '12345',
+                    prRef: 'abcd'
+                });
+
+                return Promise.resolve({ name: 'sd-checkout-code', command: 'stuff' });
+            };
+            config.build.prRef = 'abcd';
+
+            return instance.getSetupCommand(config)
+                .then((command) => {
+                    assert.equal(command, 'stuff');
+                });
+        });
+    });
+
     describe('decorateUrl', () => {
         const config = {
             scmUri: 'github.com:repoId:branch',


### PR DESCRIPTION
Converts `{ pipeline, build }` to a string representing the commands needed to checkout code for a build.