### PR TITLE
feat(379): Attach webhook to SCM repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,25 @@ This is a promise based interface for interacting with a source control manageme
 ### configure
 The `configure` function takes in an object and resets the configuration values
 
+### addWebhook
+Required parameters:
+
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| config            | Object | Configuration Object |
+| config.scmUri     | String | SCM URI to add the webhook to (e.g., "github.com:8888:branchName" |
+| config.token      | String | Access token for SCM |
+| config.webhookUrl | String | The URL to use for webhook notifications |
+
+#### Expected Outcome
+
+Update the repository with the desired webhook configuration.
+
+#### Expected Promise response
+
+1. Resolves when the webhook is correctly attached to the repository
+1. Rejects when the repository was unable to be updated with the webhook configuration
+
 ### parseUrl
 Required parameters:
 
@@ -260,6 +279,7 @@ A configuration that can be passed to the [bell][bell] OAuth module to authentic
 ## Extending
 To make use of the validation functions, the functions to override are:
 
+1. `_addWebhook`
 1. `_parseUrl`
 1. `_parseHook`
 1. `_getCheckoutCommand`

--- a/index.js
+++ b/index.js
@@ -42,6 +42,27 @@ class ScmBase {
     }
 
     /**
+     * Adds the Screwdriver webhook to the SCM repository
+     *
+     * If the repository already has the desired webhook, it will instead update the webhook to
+     * ensure it has all the up-to-date information and settings (e.g., events)
+     * @method addWebhook
+     * @param  {Object}     config
+     * @param  {String}     config.scmUri      SCM URI to add the webhook to
+     * @param  {String}     config.token       Service token to authenticate with the SCM service
+     * @param  {String}     config.webhookUrl  The URL to use for the webhook notifications
+     * @return {Promise}                       Resolves when operation completed without failure
+     */
+    addWebhook(config) {
+        return validate(config, dataSchema.plugins.scm.addWebhook)
+            .then(this._addWebhook);
+    }
+
+    _addWebhook() {
+        return Promise.reject('Not implemented');
+    }
+
+    /**
      * Parse the url for a repo for the specific source control
      * @method parseurl
      * @param  {Object}    config

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
   },
   "dependencies": {
     "joi": "^10.0.5",
-    "screwdriver-data-schema": "^15.4.0"
+    "screwdriver-data-schema": "^15.6.0"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -543,4 +543,41 @@ describe('index test', () => {
                 })
         );
     });
+
+    describe('addWebhook', () => {
+        const config = {
+            scmUri: 'github.com:20161206:branch',
+            token: 'token',
+            url: 'https://bob.by/ford'
+        };
+
+        it('returns data from underlying method', () => {
+            const expectedOutput = 'whenYourOpponentIsProgrammedToLose';
+
+            instance._addWebhook = () => Promise.resolve(expectedOutput);
+
+            return instance.addWebhook({
+                scmUri: 'github.com:20161206:branch',
+                token: 'token',
+                url: 'https://bob.by/ford'
+            }).then((result) => {
+                assert.strictEqual(result, expectedOutput);
+            });
+        });
+
+        it('rejects when given an invalid config object', () =>
+            instance.addWebhook({})
+                .then(assert.fail, (err) => {
+                    assert.instanceOf(err, Error);
+                    assert.equal(err.name, 'ValidationError');
+                })
+        );
+
+        it('rejects when not implemented', () =>
+            instance.addWebhook(config)
+               .then(assert.fail, (err) => {
+                   assert.strictEqual(err, 'Not implemented');
+               })
+        );
+    });
 });


### PR DESCRIPTION
Enable a method that adds webhooks to a specific SCM repository. In addition, if the repository already has the desired webhook, it will also refresh/update to ensure it has all the correct information. This is important for a few example scenarios:

* For Github, the webhook API secret changes.
* For Bitbucket & Github, we need to modify which kind of events Screwdriver should react to.

Related to screwdriver-cd/screwdriver#379