### PR TITLE
fix: actually calls addWebhook function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,0 @@
-# CHANGELOG
-
-## 2.4.0
-
-Features:
-  * Add method to get checkout commands for scm plugin.

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ class ScmBase {
      */
     addWebhook(config) {
         return validate(config, dataSchema.plugins.scm.addWebhook)
-            .then(this._addWebhook);
+            .then(() => this._addWebhook(config));
     }
 
     _addWebhook() {

--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
     "chai": "^3.5.0",
     "eslint": "^3.2.2",
     "eslint-config-screwdriver": "^2.0.5",
-    "jenkins-mocha": "^3.0.4"
+    "jenkins-mocha": "^4.0.0"
   },
   "dependencies": {
     "joi": "^10.0.5",
-    "screwdriver-data-schema": "^15.6.0"
+    "screwdriver-data-schema": "^16.0.2"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -548,7 +548,7 @@ describe('index test', () => {
         const config = {
             scmUri: 'github.com:20161206:branch',
             token: 'token',
-            url: 'https://bob.by/ford'
+            webhookUrl: 'https://bob.by/ford'
         };
 
         it('returns data from underlying method', () => {
@@ -559,7 +559,7 @@ describe('index test', () => {
             return instance.addWebhook({
                 scmUri: 'github.com:20161206:branch',
                 token: 'token',
-                url: 'https://bob.by/ford'
+                webhookUrl: 'https://bob.by/ford'
             }).then((result) => {
                 assert.strictEqual(result, expectedOutput);
             });


### PR DESCRIPTION
After https://github.com/screwdriver-cd/data-schema/pull/100 is merged, will get `TypeError: Cannot read property 'lookupScmUri' of undefined` because of this bug. 

Related: screwdriver-cd/screwdriver#379
Blocked by: https://github.com/screwdriver-cd/data-schema/pull/100

