### PR TITLE
fix(587): Add doc for lastCommitMessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ A key-map of data related to the received payload in the form of:
     checkoutUrl: 'https://batman@bitbucket.org/batman/test.git',
     branch: 'mynewbranch',
     sha: '9ff49b2d1437567cad2b5fed7a0706472131e927',
+    lastCommitMessage: 'This is the last commit message', // get a message of the last one from commits object
     prNum: 3,
     prRef: 'pull/3/merge'
 }


### PR DESCRIPTION
I'm working on the feature discussed on screwdriver-cd/screwdriver#587 (skip builds).
There is a change to a return object of `parseHook`, so I fixed the doc. screwdriver-cd/scm-github#64