### PR TITLE
[DNM] feat(365) - 3: add functions and docs for implementing multiple scm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ artifacts/
 npm-debug.log
 .DS_STORE
 .*.swp
+.nyc_output/

--- a/README.md
+++ b/README.md
@@ -302,6 +302,48 @@ The list of objects consist of PR names and refs (either a branch or a sha) for 
 1. Resolve with the list of objects consists of PR names and refs
 2. Reject if the input or output is not valid
 
+### getPrInfo
+The parameters required are:
+
+| Parameter        | Type  | Required | Description |
+| :-------------   | :---- | :------- | :-------------|
+| config        | Object | true | Configuration Object |
+| config.scmUri | String | true | The scm uri (ex: `github.com:1234:branchName`) |
+| config.token | String | true | Access token for scm |
+| config.prNum | Integer | true | The PR number used to fetch the PR |
+
+#### Expected Outcome
+The object consists of PR name, sha and ref for the pipeline.
+
+#### Expected Promise Response
+1. Resolve with the object consists of PR name, sha and ref
+2. Reject if the input or output is not valid
+
+### getScmContext
+No parameters are required.
+
+#### Expected Outcome
+The name of scm context (e.g. github.com, my-gitlab)
+
+#### Expected Promise Response
+1. Resolve with the name of scm context
+2. Reject if the input or output is not valid
+
+### canHandleUrl
+The parameters required are:
+
+| Parameter        | Type  | Required | Description |
+| :-------------   | :---- | :------- | :-------------|
+| config        | Object | true | Configuration Object |
+| config.scmUri | String | true | The scm uri (ex: `github.com:1234:branchName`) |
+
+#### Expected Outcome
+The uri of parameter is available or not.
+
+#### Expected Promise Response
+1. Resolve with the uri of parameter is available or not.
+2. Reject if the input or output is not valid
+
 ## Extending
 To make use of the validation functions, the functions to override are:
 
@@ -318,7 +360,10 @@ To make use of the validation functions, the functions to override are:
 1. `_getFile`
 1. `_getOpenedPRs`
 1. `_getBellConfiguration`
+1. `_getPrInfo`
 1. `stats` 
+1. `_getScmContext` 
+1. `_canHandleUrl` 
 
 ```js
 class MyScm extends ScmBase {

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ The object consists of PR name, sha and ref for the pipeline.
 1. Resolve with the object consists of PR name, sha and ref
 2. Reject if the input or output is not valid
 
-### getScmContext
+### getScmContexts
 No parameters are required.
 
 #### Expected Outcome
@@ -372,7 +372,7 @@ To make use of the validation functions, the functions to override are:
 1. `_getBellConfiguration`
 1. `_getPrInfo`
 1. `stats` 
-1. `_getScmContext` 
+1. `_getScmContexts` 
 1. `_canHandleWebhook` 
 
 ```js

--- a/README.md
+++ b/README.md
@@ -320,7 +320,12 @@ The object consists of PR name, sha and ref for the pipeline.
 2. Reject if the input or output is not valid
 
 ### getScmContext
-No parameters are required.
+The parameters required are:
+
+| Parameter        | Type  | Required | Description |
+| :-------------   | :---- | :------- | :-------------|
+| config        | Object | true | Configuration Object |
+| config.scmUrl | String | true | The scm url |
 
 #### Expected Outcome
 The name of scm context (e.g. github.com, my-gitlab)
@@ -335,13 +340,28 @@ The parameters required are:
 | Parameter        | Type  | Required | Description |
 | :-------------   | :---- | :------- | :-------------|
 | config        | Object | true | Configuration Object |
-| config.scmUri | String | true | The scm uri (ex: `github.com:1234:branchName`) |
+| config.scmUrl | String | true | The scm url |
 
 #### Expected Outcome
-The uri of parameter is available or not.
+The url of parameter is available or not.
 
 #### Expected Promise Response
-1. Resolve with the uri of parameter is available or not.
+1. Resolve with the url of parameter is available or not.
+2. Reject if the input or output is not valid
+
+### getDisplayName
+The parameters required are:
+
+| Parameter        | Type  | Required | Description |
+| :-------------   | :---- | :------- | :-------------|
+| config        | Object | true | Configuration Object |
+| config.scmContext | String | true | The scm context (e.g. github.com, my-gitlab)|
+
+#### Expected Outcome
+The display name of provided scm context
+
+#### Expected Promise Response
+1. Resolve with the display name of provides scm context
 2. Reject if the input or output is not valid
 
 ## Extending
@@ -364,6 +384,7 @@ To make use of the validation functions, the functions to override are:
 1. `stats` 
 1. `_getScmContext` 
 1. `_canHandleUrl` 
+1. `_getDisplayName` 
 
 ```js
 class MyScm extends ScmBase {

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Required parameters:
 | config.scmUri     | String | SCM URI to add the webhook to (e.g., "github.com:8888:branchName" |
 | config.token      | String | Access token for SCM |
 | config.webhookUrl | String | The URL to use for webhook notifications |
-| config.scmContext | String | The name of scm context |
+| config.scmContext | String | (optional) The name of scm context |
 
 #### Expected Outcome
 
@@ -43,7 +43,7 @@ Required parameters:
 | config             | Object | Configuration Object |
 | config.checkoutUrl | String | Checkout url for a repo to parse |
 | config.token  | String | Access token for scm |
-| config.scmContext | String | The name of scm context |
+| config.scmContext | String | (optional) The name of scm context |
 
 #### Expected Outcome
 An scmUri (ex: `github.com:1234:branchName`, where 1234 is a repo ID number), which will be a unique identifier for the repo and branch in Screwdriver.
@@ -93,7 +93,7 @@ Required parameters:
 | config.prRef | String | No | PR branch or reference |
 | config.repo | String | Yes | Scm repo (ex: guide) |
 | config.sha | String | Yes | Scm sha |
-| config.scmContext | String | The name of scm context |
+| config.scmContext | String | No | The name of scm context |
 
 #### Expected Outcome
 Checkout command in the form of:
@@ -127,7 +127,7 @@ Required parameters:
 | config        | Object | Configuration Object |
 | config.scmUri | String | Scm uri (ex: `github.com:1234:branchName`) |
 | config.token  | String | Access token for scm |
-| config.scmContext | String | The name of scm context |
+| config.scmContext | String | (optional) The name of scm context |
 
 #### Expected Outcome
 Decorated url in the form of:
@@ -152,7 +152,7 @@ Required parameters:
 | config.scmUri        | String | Scm uri (ex: `github.com:1234:branchName`) |
 | config.sha     | String | Commit sha to decorate |
 | config.token | String | Access token for scm |
-| config.scmContext | String | The name of scm context |
+| config.scmContext | String | (optional) The name of scm context |
 
 #### Expected Outcome
 Decorated commit in the form of:
@@ -181,7 +181,7 @@ Required parameters:
 | config        | Object | Configuration Object |
 | config.token | String | Access token for scm |
 | config.username     | String | Author to decorate |
-| config.scmContext | String | The name of scm context |
+| config.scmContext | String | (optional) The name of scm context |
 
 #### Expected Outcome
 Decorated author in the form of:
@@ -206,7 +206,7 @@ Required parameters:
 | config        | Object | Configuration Object |
 | config.scmUri | String | The scm uri to get permissions on (ex: `github.com:1234:branchName`) |
 | config.token | String | Access token for scm |
-| config.scmContext | String | The name of scm context |
+| config.scmContext | String | (optional) The name of scm context |
 
 #### Expected Outcome
 Permissions for a given token on a repository in the form of:
@@ -230,7 +230,7 @@ Required parameters:
 | config        | Object | Configuration Object |
 | config.scmUri | String | The scm uri (ex: `github.com:1234:branchName`) |
 | config.token | String | Access token for scm |
-| config.scmContext | String | The name of scm context |
+| config.scmContext | String | (optional) The name of scm context |
 
 #### Expected Outcome
 The commit sha for a given branch on a repository.
@@ -252,7 +252,7 @@ The parameters required are:
 | config.token | String | Yes | Access token for scm |
 | config.url | String | No | The target url for setting up details |
 | config.pipelineId | Number | No | The pipeline id |
-| config.scmContext | String | The name of scm context |
+| config.scmContext | String | No | The name of scm context |
 
 #### Expected Outcome
 Update the commit status for a given repository and sha.
@@ -266,12 +266,12 @@ The parameters required are:
 
 | Parameter        | Type  | Required | Description |
 | :-------------   | :---- | :------- | :-------------|
-| config        | Object | true | Configuration Object |
-| config.path | String | true | The path to the file on scm to read |
-| config.ref | String | false | The reference to the scm repo, could be a branch or sha |
-| config.scmUri | String | true | The scm uri (ex: `github.com:1234:branchName`) |
-| config.token | String | true | Access token for scm |
-| config.scmContext | String | The name of scm context |
+| config        | Object | Yes | Configuration Object |
+| config.path | String | Yes | The path to the file on scm to read |
+| config.ref | String | No | The reference to the scm repo, could be a branch or sha |
+| config.scmUri | String | Yes | The scm uri (ex: `github.com:1234:branchName`) |
+| config.token | String | Yes | Access token for scm |
+| config.scmContext | String | No | The name of scm context |
 
 #### Expected Outcome
 The contents of the file at `path` in the repository
@@ -293,10 +293,10 @@ The parameters required are:
 
 | Parameter        | Type  | Required | Description |
 | :-------------   | :---- | :------- | :-------------|
-| config        | Object | true | Configuration Object |
-| config.scmUri | String | true | The scm uri (ex: `github.com:1234:branchName`) |
-| config.token | String | true | Access token for scm |
-| config.scmContext | String | The name of scm context |
+| config        | Object | Yes | Configuration Object |
+| config.scmUri | String | Yes | The scm uri (ex: `github.com:1234:branchName`) |
+| config.token | String | Yes | Access token for scm |
+| config.scmContext | String | No | The name of scm context |
 
 #### Expected Outcome
 The list of objects consist of PR names and refs (either a branch or a sha) for the pipeline. For example:
@@ -318,11 +318,11 @@ The parameters required are:
 
 | Parameter        | Type  | Required | Description |
 | :-------------   | :---- | :------- | :-------------|
-| config        | Object | true | Configuration Object |
-| config.scmUri | String | true | The scm uri (ex: `github.com:1234:branchName`) |
-| config.token | String | true | Access token for scm |
-| config.prNum | Integer | true | The PR number used to fetch the PR |
-| config.scmContext | String | The name of scm context |
+| config        | Object | Yes | Configuration Object |
+| config.scmUri | String | Yes | The scm uri (ex: `github.com:1234:branchName`) |
+| config.token | String | Yes | Access token for scm |
+| config.prNum | Integer | Yes | The PR number used to fetch the PR |
+| config.scmContext | String | No | The name of scm context |
 
 #### Expected Outcome
 The object consists of PR name, sha and ref for the pipeline.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Required parameters:
 | config.scmUri     | String | SCM URI to add the webhook to (e.g., "github.com:8888:branchName" |
 | config.token      | String | Access token for SCM |
 | config.webhookUrl | String | The URL to use for webhook notifications |
+| config.scmContext | String | The name of scm context |
 
 #### Expected Outcome
 
@@ -42,6 +43,7 @@ Required parameters:
 | config             | Object | Configuration Object |
 | config.checkoutUrl | String | Checkout url for a repo to parse |
 | config.token  | String | Access token for scm |
+| config.scmContext | String | The name of scm context |
 
 #### Expected Outcome
 An scmUri (ex: `github.com:1234:branchName`, where 1234 is a repo ID number), which will be a unique identifier for the repo and branch in Screwdriver.
@@ -91,6 +93,7 @@ Required parameters:
 | config.prRef | String | No | PR branch or reference |
 | config.repo | String | Yes | Scm repo (ex: guide) |
 | config.sha | String | Yes | Scm sha |
+| config.scmContext | String | The name of scm context |
 
 #### Expected Outcome
 Checkout command in the form of:
@@ -124,6 +127,7 @@ Required parameters:
 | config        | Object | Configuration Object |
 | config.scmUri | String | Scm uri (ex: `github.com:1234:branchName`) |
 | config.token  | String | Access token for scm |
+| config.scmContext | String | The name of scm context |
 
 #### Expected Outcome
 Decorated url in the form of:
@@ -148,6 +152,7 @@ Required parameters:
 | config.scmUri        | String | Scm uri (ex: `github.com:1234:branchName`) |
 | config.sha     | String | Commit sha to decorate |
 | config.token | String | Access token for scm |
+| config.scmContext | String | The name of scm context |
 
 #### Expected Outcome
 Decorated commit in the form of:
@@ -176,6 +181,7 @@ Required parameters:
 | config        | Object | Configuration Object |
 | config.token | String | Access token for scm |
 | config.username     | String | Author to decorate |
+| config.scmContext | String | The name of scm context |
 
 #### Expected Outcome
 Decorated author in the form of:
@@ -200,6 +206,7 @@ Required parameters:
 | config        | Object | Configuration Object |
 | config.scmUri | String | The scm uri to get permissions on (ex: `github.com:1234:branchName`) |
 | config.token | String | Access token for scm |
+| config.scmContext | String | The name of scm context |
 
 #### Expected Outcome
 Permissions for a given token on a repository in the form of:
@@ -223,6 +230,7 @@ Required parameters:
 | config        | Object | Configuration Object |
 | config.scmUri | String | The scm uri (ex: `github.com:1234:branchName`) |
 | config.token | String | Access token for scm |
+| config.scmContext | String | The name of scm context |
 
 #### Expected Outcome
 The commit sha for a given branch on a repository.
@@ -244,6 +252,7 @@ The parameters required are:
 | config.token | String | Yes | Access token for scm |
 | config.url | String | No | The target url for setting up details |
 | config.pipelineId | Number | No | The pipeline id |
+| config.scmContext | String | The name of scm context |
 
 #### Expected Outcome
 Update the commit status for a given repository and sha.
@@ -262,6 +271,7 @@ The parameters required are:
 | config.ref | String | false | The reference to the scm repo, could be a branch or sha |
 | config.scmUri | String | true | The scm uri (ex: `github.com:1234:branchName`) |
 | config.token | String | true | Access token for scm |
+| config.scmContext | String | The name of scm context |
 
 #### Expected Outcome
 The contents of the file at `path` in the repository
@@ -286,6 +296,7 @@ The parameters required are:
 | config        | Object | true | Configuration Object |
 | config.scmUri | String | true | The scm uri (ex: `github.com:1234:branchName`) |
 | config.token | String | true | Access token for scm |
+| config.scmContext | String | The name of scm context |
 
 #### Expected Outcome
 The list of objects consist of PR names and refs (either a branch or a sha) for the pipeline. For example:
@@ -311,6 +322,7 @@ The parameters required are:
 | config.scmUri | String | true | The scm uri (ex: `github.com:1234:branchName`) |
 | config.token | String | true | Access token for scm |
 | config.prNum | Integer | true | The PR number used to fetch the PR |
+| config.scmContext | String | The name of scm context |
 
 #### Expected Outcome
 The object consists of PR name, sha and ref for the pipeline.

--- a/README.md
+++ b/README.md
@@ -325,9 +325,8 @@ No parameters are required.
 #### Expected Outcome
 The array of scm context name (e.g. [github.com, my-gitlab])
 
-#### Expected Promise Response
-1. Resolve with the array of scm context name
-2. Reject if the input or output is not valid
+#### Expected Response
+1. The array of scm context name
 
 ### canHandleWebhook
 The parameters required are:
@@ -350,9 +349,8 @@ No parameters are required.
 #### Expected Outcome
 The display name of scm context
 
-#### Expected Promise Response
-1. Resolve with the display name of scm context
-2. Reject if the input or output is not valid
+#### Expected Response
+1. The display name of scm context
 
 ## Extending
 To make use of the validation functions, the functions to override are:

--- a/README.md
+++ b/README.md
@@ -320,48 +320,38 @@ The object consists of PR name, sha and ref for the pipeline.
 2. Reject if the input or output is not valid
 
 ### getScmContext
-The parameters required are:
-
-| Parameter        | Type  | Required | Description |
-| :-------------   | :---- | :------- | :-------------|
-| config        | Object | true | Configuration Object |
-| config.scmUrl | String | true | The scm url |
+No parameters are required.
 
 #### Expected Outcome
-The name of scm context (e.g. github.com, my-gitlab)
+The array of scm context name (e.g. [github.com, my-gitlab])
 
 #### Expected Promise Response
-1. Resolve with the name of scm context
+1. Resolve with the array of scm context name
 2. Reject if the input or output is not valid
 
-### canHandleUrl
+### canHandleWebhook
 The parameters required are:
 
-| Parameter        | Type  | Required | Description |
-| :-------------   | :---- | :------- | :-------------|
-| config        | Object | true | Configuration Object |
-| config.scmUrl | String | true | The scm url |
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| headers        | Object | The request headers associated with the webhook payload |
+| payload        | Object | The webhook payload received from the SCM service |
 
 #### Expected Outcome
-The url of parameter is available or not.
+The received webhook is available or not as boolean.
 
 #### Expected Promise Response
-1. Resolve with the url of parameter is available or not.
+1. Resolve with the received webhook is available or not.
 2. Reject if the input or output is not valid
 
 ### getDisplayName
-The parameters required are:
-
-| Parameter        | Type  | Required | Description |
-| :-------------   | :---- | :------- | :-------------|
-| config        | Object | true | Configuration Object |
-| config.scmContext | String | true | The scm context (e.g. github.com, my-gitlab)|
+No parameters are required.
 
 #### Expected Outcome
-The display name of provided scm context
+The display name of scm context
 
 #### Expected Promise Response
-1. Resolve with the display name of provides scm context
+1. Resolve with the display name of scm context
 2. Reject if the input or output is not valid
 
 ## Extending
@@ -383,8 +373,7 @@ To make use of the validation functions, the functions to override are:
 1. `_getPrInfo`
 1. `stats` 
 1. `_getScmContext` 
-1. `_canHandleUrl` 
-1. `_getDisplayName` 
+1. `_canHandleWebhook` 
 
 ```js
 class MyScm extends ScmBase {

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ The object consists of PR name, sha and ref for the pipeline.
 No parameters are required.
 
 #### Expected Outcome
-The array of scm context name (e.g. [github.com, my-gitlab])
+The array of scm context name (e.g. [github:github.com, gitlab:my-gitlab])
 
 #### Expected Response
 1. The array of scm context name

--- a/README.md
+++ b/README.md
@@ -343,8 +343,12 @@ The received webhook is available or not as boolean.
 1. Resolve with the received webhook is available or not.
 2. Reject if the input or output is not valid
 
-### getDisplayName
-No parameters are required.
+### getDisplayName (overriding needs only the case of `scm-router`)
+The parameters required are:
+
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| scmContext        | String | The name of scm context |
 
 #### Expected Outcome
 The display name of scm context
@@ -372,6 +376,7 @@ To make use of the validation functions, the functions to override are:
 1. `stats` 
 1. `_getScmContexts` 
 1. `_canHandleWebhook` 
+1. `getDisplayName` (overriding needs only the case of `scm-router`) 
 
 ```js
 class MyScm extends ScmBase {

--- a/index.js
+++ b/index.js
@@ -7,18 +7,19 @@ const dataSchema = require('screwdriver-data-schema');
 /**
  * Validate the config using the schema
  * @method  validate
- * @param  {Object}    config       Configuration
- * @param  {Object}    schema       Joi object used for validation
- * @return {Promise}
+ * @param  {Object}    config           Configuration
+ * @param  {Object}    schema           Joi object used for validation
+ * @param  {Boolean}   notPromise       If true, return Object
+ * @return {Promise|Object}
  */
-function validate(config, schema) {
+function validate(config, schema, notPromise) {
     const result = Joi.validate(config, schema);
 
     if (result.error) {
-        return Promise.reject(result.error);
+        return notPromise ? result.error : Promise.reject(result.error);
     }
 
-    return Promise.resolve(config);
+    return notPromise ? config : Promise.resolve(config);
 }
 
 class ScmBase {
@@ -366,7 +367,7 @@ class ScmBase {
     getScmContexts() {
         return validate(this._getScmContexts(), Joi.array().items(
                 Joi.reach(dataSchema.models.pipeline.base, 'scmContext').required()
-            ));
+            ), true);
     }
 
     _getScmContexts() {

--- a/index.js
+++ b/index.js
@@ -44,11 +44,11 @@ class ScmBase {
      * ensure it has all the up-to-date information and settings (e.g., events)
      * @method addWebhook
      * @param  {Object}     config
-     * @param  {String}     config.scmUri      SCM URI to add the webhook to
-     * @param  {String}     config.token       Service token to authenticate with the SCM service
-     * @param  {String}     config.webhookUrl  The URL to use for the webhook notifications
-     * @param  {String}     config.scmContext  The scm context name
-     * @return {Promise}                       Resolves when operation completed without failure
+     * @param  {String}     config.scmUri           SCM URI to add the webhook to
+     * @param  {String}     config.token            Service token to authenticate with the SCM service
+     * @param  {String}     config.webhookUrl       The URL to use for the webhook notifications
+     * @param  {String}     [config.scmContext]     The scm context name
+     * @return {Promise}                            Resolves when operation completed without failure
      */
     addWebhook(config) {
         return validate(config, dataSchema.plugins.scm.addWebhook)
@@ -65,7 +65,7 @@ class ScmBase {
      * @param  {Object}    config
      * @param  {String}    config.checkoutUrl       Url to parse
      * @param  {String}    config.token             The token used to authenticate to the SCM
-     * @param  {String}    config.scmContext        The scm context name
+     * @param  {String}    [config.scmContext]      The scm context name
      * @return {Promise}
      */
     parseUrl(config) {
@@ -97,13 +97,13 @@ class ScmBase {
      * Checkout the source code from a repository; resolves as an object with checkout commands
      * @method getCheckoutCommand
      * @param  {Object}    config
-     * @param  {String}    config.branch        Pipeline branch
-     * @param  {String}    config.host          Scm host to checkout source code from
-     * @param  {String}    config.org           Scm org name
-     * @param  {String}    config.repo          Scm repo name
-     * @param  {String}    config.sha           Commit sha
-     * @param  {String}    config.scmContext    The scm context name
-     * @param  {String}    [config.prRef]       PR reference (can be a PR branch or reference)
+     * @param  {String}    config.branch          Pipeline branch
+     * @param  {String}    config.host            Scm host to checkout source code from
+     * @param  {String}    config.org             Scm org name
+     * @param  {String}    config.repo            Scm repo name
+     * @param  {String}    config.sha             Commit sha
+     * @param  {String}    [config.scmContext]    The scm context name
+     * @param  {String}    [config.prRef]         PR reference (can be a PR branch or reference)
      * @return {Promise}
      */
     getCheckoutCommand(config) {
@@ -148,9 +148,9 @@ class ScmBase {
      * Decorate the url for the specific source control
      * @method decorateUrl
      * @param  {Object}    config
-     * @param  {String}    config.scmUri       SCM uri to decorate
-     * @param  {String}    config.token        The token used to authenticate to the SCM
-     * @param  {String}    config.scmContext   The scm context name
+     * @param  {String}    config.scmUri         SCM uri to decorate
+     * @param  {String}    config.token          The token used to authenticate to the SCM
+     * @param  {String}    [config.scmContext]   The scm context name
      * @return {Promise}
      */
     decorateUrl(config) {
@@ -167,10 +167,10 @@ class ScmBase {
      * Decorate the commit for the specific source control
      * @method decorateCommit
      * @param  {Object}    config
-     * @param  {String}    config.sha           Commit sha to decorate
-     * @param  {String}    config.scmUri        SCM uri
-     * @param  {String}    config.token         The token used to authenticate to the SCM
-     * @param  {String}    config.scmContext    The scm context name
+     * @param  {String}    config.sha             Commit sha to decorate
+     * @param  {String}    config.scmUri          SCM uri
+     * @param  {String}    config.token           The token used to authenticate to the SCM
+     * @param  {String}    [config.scmContext]    The scm context name
      * @return {Promise}
      */
     decorateCommit(config) {
@@ -187,9 +187,9 @@ class ScmBase {
      * Decorate the author for the specific source control
      * @method decorateAuthor
      * @param  {Object}    config
-     * @param  {String}    config.username      Author to decorate
-     * @param  {String}    config.token         The token used to authenticate to the SCM
-     * @param  {String}    config.scmContext    The scm context name
+     * @param  {String}    config.username        Author to decorate
+     * @param  {String}    config.token           The token used to authenticate to the SCM
+     * @param  {String}    [config.scmContext]    The scm context name
      * @return {Promise}
      */
     decorateAuthor(config) {
@@ -205,10 +205,10 @@ class ScmBase {
     /**
      * Get a users permissions on a repository
      * @method getPermissions
-     * @param  {Object}   config                Configuration
-     * @param  {String}   config.scmUri         The scmUri to get permissions on
-     * @param  {String}   config.token          The token used to authenticate to the SCM
-     * @param  {String}   config.scmContext     The scm context name
+     * @param  {Object}   config                  Configuration
+     * @param  {String}   config.scmUri           The scmUri to get permissions on
+     * @param  {String}   config.token            The token used to authenticate to the SCM
+     * @param  {String}   [config.scmContext]     The scm context name
      * @return {Promise}
      */
     getPermissions(config) {
@@ -223,11 +223,11 @@ class ScmBase {
     /**
      * Get a commit sha for a specific repo#branch or pull request
      * @method getCommitSha
-     * @param  {Object}   config                Configuration
-     * @param  {String}   config.scmUri         The scmUri to get commit sha of
-     * @param  {String}   config.token          The token used to authenticate to the SCM
-     * @param  {String}   config.scmContext     The scm context name
-     * @param  {Integer}  [config.prNum]        The PR number used to fetch the sha
+     * @param  {Object}   config                  Configuration
+     * @param  {String}   config.scmUri           The scmUri to get commit sha of
+     * @param  {String}   config.token            The token used to authenticate to the SCM
+     * @param  {String}   [config.scmContext]     The scm context name
+     * @param  {Integer}  [config.prNum]          The PR number used to fetch the sha
      * @return {Promise}
      */
     getCommitSha(config) {
@@ -242,15 +242,15 @@ class ScmBase {
     /**
      * Update the commit status for a given repo and sha
      * @method updateCommitStatus
-     * @param  {Object}   config                Configuration
-     * @param  {String}   config.scmUri         The scmUri to get permissions on
-     * @param  {String}   config.sha            The sha to apply the status to
-     * @param  {String}   config.buildStatus    The build status used for figuring out the commit status to set
-     * @param  {String}   config.token          The token used to authenticate to the SCM
-     * @param  {String}   [config.jobName]      Optional name of the job that finished
-     * @param  {String}   config.url            Target url
-     * @param  {Number}   [config.pipelineId]   Pipeline ID
-     * @param  {String}   config.scmContext     The scm context name
+     * @param  {Object}   config                  Configuration
+     * @param  {String}   config.scmUri           The scmUri to get permissions on
+     * @param  {String}   config.sha              The sha to apply the status to
+     * @param  {String}   config.buildStatus      The build status used for figuring out the commit status to set
+     * @param  {String}   config.token            The token used to authenticate to the SCM
+     * @param  {String}   [config.jobName]        Optional name of the job that finished
+     * @param  {String}   config.url              Target url
+     * @param  {Number}   [config.pipelineId]     Pipeline ID
+     * @param  {String}   [config.scmContext]     The scm context name
      * @return {Promise}
      */
     updateCommitStatus(config) {
@@ -265,11 +265,11 @@ class ScmBase {
     /**
      * Fetch content of a file from an scm repo
      * @method getFile
-     * @param  {Object}   config              Configuration
-     * @param  {String}   config.scmUri       The scmUri to get permissions on
-     * @param  {String}   config.path         The file in the repo to fetch
-     * @param  {String}   config.token        The token used to authenticate to the SCM
-     * @param  {String}   config.scmContext   The scm context name
+     * @param  {Object}   config                Configuration
+     * @param  {String}   config.scmUri         The scmUri to get permissions on
+     * @param  {String}   config.path           The file in the repo to fetch
+     * @param  {String}   config.token          The token used to authenticate to the SCM
+     * @param  {String}   [config.scmContext]   The scm context name
      * @return {Promise}
      */
     getFile(config) {
@@ -284,10 +284,10 @@ class ScmBase {
     /**
      * Get list of objects which consists of opened PR names and its ref
      * @method getOpenedPRs
-     * @param  {Object}   config              Configuration
-     * @param  {String}   config.scmUri       The scmUri to get opened PRs
-     * @param  {String}   config.token        The token used to authenticate to the SCM
-     * @param  {String}   config.scmContext   The scm context name
+     * @param  {Object}   config                Configuration
+     * @param  {String}   config.scmUri         The scmUri to get opened PRs
+     * @param  {String}   config.token          The token used to authenticate to the SCM
+     * @param  {String}   [config.scmContext]   The scm context name
      * @return {Promise}
      */
     getOpenedPRs(config) {
@@ -323,11 +323,11 @@ class ScmBase {
     /**
      * Resolve a pull request object based on the config
      * @method getPrInfo
-     * @param  {Object}   config                Configuration
-     * @param  {String}   config.scmUri         The scmUri to get PR info of
-     * @param  {String}   config.token          The token used to authenticate to the SCM
-     * @param  {Integer}  config.prNum          The PR number used to fetch the PR
-     * @param  {String}   config.scmContext     The scm context name
+     * @param  {Object}   config                    Configuration
+     * @param  {String}   config.scmUri             The scmUri to get PR info of
+     * @param  {String}   config.token              The token used to authenticate to the SCM
+     * @param  {Integer}  config.prNum              The PR number used to fetch the PR
+     * @param  {String}   [config.scmContext]       The scm context name
      * @return {Promise}
      */
     getPrInfo(config) {

--- a/index.js
+++ b/index.js
@@ -7,19 +7,18 @@ const dataSchema = require('screwdriver-data-schema');
 /**
  * Validate the config using the schema
  * @method  validate
- * @param  {Object}    config           Configuration
- * @param  {Object}    schema           Joi object used for validation
- * @param  {Boolean}   notPromise       If true, return Object
- * @return {Promise|Object}
+ * @param  {Object}    config       Configuration
+ * @param  {Object}    schema       Joi object used for validation
+ * @return {Promise}
  */
-function validate(config, schema, notPromise) {
+function validate(config, schema) {
     const result = Joi.validate(config, schema);
 
     if (result.error) {
-        return notPromise ? result.error : Promise.reject(result.error);
+        return Promise.reject(result.error);
     }
 
-    return notPromise ? config : Promise.resolve(config);
+    return Promise.resolve(config);
 }
 
 class ScmBase {
@@ -367,7 +366,7 @@ class ScmBase {
     getScmContexts() {
         return validate(this._getScmContexts(), Joi.array().items(
                 Joi.reach(dataSchema.models.pipeline.base, 'scmContext').required()
-            ), true);
+            ));
     }
 
     _getScmContexts() {

--- a/index.js
+++ b/index.js
@@ -346,17 +346,14 @@ class ScmBase {
     }
 
     /**
-     * Get a name of scm context (e.g. github.com)
+     * Get an array of scm context (e.g. [github.com, mygitlab_gitlab])
      * @method getScmContext
-     * @param  {Object}   config            Configuration
-     * @param  {String}   config.scmUrl     The scmUrl to get scm context
      * @return {Promise}
      */
-    getScmContext(config) {
-        return validate(config, dataSchema.plugins.scm.getScmContext)
-             .then(validConfig => this._getScmContext(validConfig))
-             .then(scmContext => validate(scmContext,
-                Joi.reach(dataSchema.models.pipeline.base, 'scmContext').required()));
+    getScmContext() {
+        return this._getScmContext().then(scmContext => validate(scmContext,
+            Joi.array().items(Joi.reach(dataSchema.models.pipeline.base, 'scmContext')
+                .required())));
     }
 
     _getScmContext() {
@@ -364,37 +361,27 @@ class ScmBase {
     }
 
     /**
-     * Determine a scm module can handle a specified scm url
-     * @method canHandleUrl
-     * @param  {Object}   config            Configuration
-     * @param  {String}   config.scmUrl     The scmUrl to determine to handle or not to handle
+     * Determine a scm module can handle the received webhook
+     * @method canHandleWebhook
+     * @param  {Object}     headers     The request headers associated with the webhook payload
+     * @param  {Object}     payload     The webhook payload received from the SCM service
      * @return {Promise}
      */
-    canHandleUrl(config) {
-        return validate(config, dataSchema.plugins.scm.canHandleUrl)
-             .then(validConfig => this._canHandleUrl(validConfig))
-             .then(canHandle => validate(canHandle, Joi.bool().required()));
+    canHandleWebhook(headers, payload) {
+        return this._canHandleWebhook(headers, payload);
     }
 
-    _canHandleUrl() {
+    _canHandleWebhook() {
         return Promise.reject('Not implemented');
     }
 
     /**
      * Get a name of scm context to display
      * @method getDisplayName
-     * @param  {Object}   config                Configuration
-     * @param  {String}   config.scmContext     The using scmContext
-     * @return {Promise}
+     * @return {String}
      */
-    getDisplayName(config) {
-        return validate(config, dataSchema.plugins.scm.getDisplayName)
-             .then(validConfig => this._getDisplayName(validConfig))
-             .then(displayName => validate(displayName, Joi.string().required()));
-    }
-
-    _getDisplayName() {
-        return Promise.reject('Not implemented');
+    getDisplayName() {
+        return this.config.displayName || '';
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -344,6 +344,35 @@ class ScmBase {
     stats() {
         return {};
     }
+
+    /**
+     * Get a name of scm context (e.g. github.com)
+     * @method getScmContext
+     * @return {Promise}
+     */
+    getScmContext() {
+        return this._getScmContext()
+             .then(scmContext => validate(scmContext, Joi.string().required()));
+    }
+
+    _getScmContext() {
+        return Promise.reject('Not implemented');
+    }
+
+    /**
+     * Determine a scm module can handle a specified scm url
+     * @method canHandleUrl
+     * @return {Promise}
+     */
+    canHandleUrl(config) {
+        return validate(config, dataSchema.plugins.scm.canHandleUrl)
+             .then(validConfig => this._canHandleUrl(validConfig))
+             .then(canHandle => validate(canHandle, Joi.bool().required()));
+    }
+
+    _canHandleUrl() {
+        return Promise.reject('Not implemented');
+    }
 }
 
 module.exports = ScmBase;

--- a/index.js
+++ b/index.js
@@ -134,7 +134,8 @@ class ScmBase {
             host,
             org,
             repo,
-            sha: o.build.sha
+            sha: o.build.sha,
+            scmContext: o.pipeline.scmContext
         };
 
         if (o.build.prRef) {

--- a/index.js
+++ b/index.js
@@ -347,16 +347,16 @@ class ScmBase {
 
     /**
      * Get an array of scm context (e.g. [github.com, mygitlab_gitlab])
-     * @method getScmContext
+     * @method getScmContexts
      * @return {Promise}
      */
-    getScmContext() {
-        return this._getScmContext().then(scmContext => validate(scmContext,
+    getScmContexts() {
+        return this._getScmContexts().then(scmContexts => validate(scmContexts,
             Joi.array().items(Joi.reach(dataSchema.models.pipeline.base, 'scmContext')
                 .required())));
     }
 
-    _getScmContext() {
+    _getScmContexts() {
         return Promise.reject('Not implemented');
     }
 

--- a/index.js
+++ b/index.js
@@ -14,11 +14,7 @@ const dataSchema = require('screwdriver-data-schema');
 function validate(config, schema) {
     const result = Joi.validate(config, schema);
 
-    if (result.error) {
-        return Promise.reject(result.error);
-    }
-
-    return Promise.resolve(config);
+    return result.error ? Promise.reject(result.error) : Promise.resolve(config);
 }
 
 class ScmBase {
@@ -359,14 +355,17 @@ class ScmBase {
     }
 
     /**
-     * Get an array of scm context (e.g. [github.com, mygitlab_gitlab])
+     * Get an array of scm context (e.g. [github:github.com, gitlab:mygitlab])
      * @method getScmContexts
      * @return {Array}
      */
     getScmContexts() {
-        return validate(this._getScmContexts(), Joi.array().items(
-                Joi.reach(dataSchema.models.pipeline.base, 'scmContext').required()
-            ));
+        const result = this._getScmContexts();
+        const validateResult = Joi.validate(result, Joi.array().items(
+            Joi.reach(dataSchema.models.pipeline.base, 'scmContext').required()
+        ));
+
+        return validateResult.error || result;
     }
 
     _getScmContexts() {

--- a/index.js
+++ b/index.js
@@ -348,16 +348,14 @@ class ScmBase {
     /**
      * Get an array of scm context (e.g. [github.com, mygitlab_gitlab])
      * @method getScmContexts
-     * @return {Promise}
+     * @return {Array}
      */
     getScmContexts() {
-        return this._getScmContexts().then(scmContexts => validate(scmContexts,
-            Joi.array().items(Joi.reach(dataSchema.models.pipeline.base, 'scmContext')
-                .required())));
+        return this._getScmContexts();
     }
 
     _getScmContexts() {
-        return Promise.reject('Not implemented');
+        throw new Error('Not implemented');
     }
 
     /**

--- a/index.js
+++ b/index.js
@@ -351,7 +351,9 @@ class ScmBase {
      * @return {Array}
      */
     getScmContexts() {
-        return this._getScmContexts();
+        return validate(this._getScmContexts(), Joi.array().items(
+                Joi.reach(dataSchema.models.pipeline.base, 'scmContext').required()
+            ));
     }
 
     _getScmContexts() {

--- a/index.js
+++ b/index.js
@@ -326,7 +326,7 @@ class ScmBase {
 
     /**
      * Resolve a pull request object based on the config
-     * @method getPrRef
+     * @method getPrInfo
      * @param  {Object}   config                Configuration
      * @param  {String}   config.scmUri         The scmUri to get PR info of
      * @param  {String}   config.token          The token used to authenticate to the SCM

--- a/index.js
+++ b/index.js
@@ -348,11 +348,15 @@ class ScmBase {
     /**
      * Get a name of scm context (e.g. github.com)
      * @method getScmContext
+     * @param  {Object}   config            Configuration
+     * @param  {String}   config.scmUrl     The scmUrl to get scm context
      * @return {Promise}
      */
-    getScmContext() {
-        return this._getScmContext()
-             .then(scmContext => validate(scmContext, Joi.string().required()));
+    getScmContext(config) {
+        return validate(config, dataSchema.plugins.scm.getScmContext)
+             .then(validConfig => this._getScmContext(validConfig))
+             .then(scmContext => validate(scmContext,
+                Joi.reach(dataSchema.models.pipeline.base, 'scmContext').required()));
     }
 
     _getScmContext() {
@@ -362,6 +366,8 @@ class ScmBase {
     /**
      * Determine a scm module can handle a specified scm url
      * @method canHandleUrl
+     * @param  {Object}   config            Configuration
+     * @param  {String}   config.scmUrl     The scmUrl to determine to handle or not to handle
      * @return {Promise}
      */
     canHandleUrl(config) {
@@ -371,6 +377,23 @@ class ScmBase {
     }
 
     _canHandleUrl() {
+        return Promise.reject('Not implemented');
+    }
+
+    /**
+     * Get a name of scm context to display
+     * @method getDisplayName
+     * @param  {Object}   config                Configuration
+     * @param  {String}   config.scmContext     The using scmContext
+     * @return {Promise}
+     */
+    getDisplayName(config) {
+        return validate(config, dataSchema.plugins.scm.getDisplayName)
+             .then(validConfig => this._getDisplayName(validConfig))
+             .then(displayName => validate(displayName, Joi.string().required()));
+    }
+
+    _getDisplayName() {
         return Promise.reject('Not implemented');
     }
 }

--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ class ScmBase {
      * @param  {String}     config.scmUri      SCM URI to add the webhook to
      * @param  {String}     config.token       Service token to authenticate with the SCM service
      * @param  {String}     config.webhookUrl  The URL to use for the webhook notifications
+     * @param  {String}     config.scmContext  The scm context name
      * @return {Promise}                       Resolves when operation completed without failure
      */
     addWebhook(config) {
@@ -68,6 +69,7 @@ class ScmBase {
      * @param  {Object}    config
      * @param  {String}    config.checkoutUrl       Url to parse
      * @param  {String}    config.token             The token used to authenticate to the SCM
+     * @param  {String}    config.scmContext        The scm context name
      * @return {Promise}
      */
     parseUrl(config) {
@@ -104,6 +106,7 @@ class ScmBase {
      * @param  {String}    config.org           Scm org name
      * @param  {String}    config.repo          Scm repo name
      * @param  {String}    config.sha           Commit sha
+     * @param  {String}    config.scmContext    The scm context name
      * @param  {String}    [config.prRef]       PR reference (can be a PR branch or reference)
      * @return {Promise}
      */
@@ -151,6 +154,7 @@ class ScmBase {
      * @param  {Object}    config
      * @param  {String}    config.scmUri       SCM uri to decorate
      * @param  {String}    config.token        The token used to authenticate to the SCM
+     * @param  {String}    config.scmContext   The scm context name
      * @return {Promise}
      */
     decorateUrl(config) {
@@ -170,6 +174,7 @@ class ScmBase {
      * @param  {String}    config.sha           Commit sha to decorate
      * @param  {String}    config.scmUri        SCM uri
      * @param  {String}    config.token         The token used to authenticate to the SCM
+     * @param  {String}    config.scmContext    The scm context name
      * @return {Promise}
      */
     decorateCommit(config) {
@@ -186,8 +191,9 @@ class ScmBase {
      * Decorate the author for the specific source control
      * @method decorateAuthor
      * @param  {Object}    config
-     * @param  {String}    config.username  Author to decorate
-     * @param  {String}    config.token     The token used to authenticate to the SCM
+     * @param  {String}    config.username      Author to decorate
+     * @param  {String}    config.token         The token used to authenticate to the SCM
+     * @param  {String}    config.scmContext    The scm context name
      * @return {Promise}
      */
     decorateAuthor(config) {
@@ -203,9 +209,10 @@ class ScmBase {
     /**
      * Get a users permissions on a repository
      * @method getPermissions
-     * @param  {Object}   config            Configuration
-     * @param  {String}   config.scmUri     The scmUri to get permissions on
-     * @param  {String}   config.token      The token used to authenticate to the SCM
+     * @param  {Object}   config                Configuration
+     * @param  {String}   config.scmUri         The scmUri to get permissions on
+     * @param  {String}   config.token          The token used to authenticate to the SCM
+     * @param  {String}   config.scmContext     The scm context name
      * @return {Promise}
      */
     getPermissions(config) {
@@ -220,10 +227,11 @@ class ScmBase {
     /**
      * Get a commit sha for a specific repo#branch or pull request
      * @method getCommitSha
-     * @param  {Object}   config            Configuration
-     * @param  {String}   config.scmUri     The scmUri to get commit sha of
-     * @param  {String}   config.token      The token used to authenticate to the SCM
-     * @param  {Integer}  [config.prNum]    The PR number used to fetch the sha
+     * @param  {Object}   config                Configuration
+     * @param  {String}   config.scmUri         The scmUri to get commit sha of
+     * @param  {String}   config.token          The token used to authenticate to the SCM
+     * @param  {String}   config.scmContext     The scm context name
+     * @param  {Integer}  [config.prNum]        The PR number used to fetch the sha
      * @return {Promise}
      */
     getCommitSha(config) {
@@ -238,14 +246,15 @@ class ScmBase {
     /**
      * Update the commit status for a given repo and sha
      * @method updateCommitStatus
-     * @param  {Object}   config              Configuration
-     * @param  {String}   config.scmUri       The scmUri to get permissions on
-     * @param  {String}   config.sha          The sha to apply the status to
-     * @param  {String}   config.buildStatus  The build status used for figuring out the commit status to set
-     * @param  {String}   config.token        The token used to authenticate to the SCM
-     * @param  {String}   [config.jobName]    Optional name of the job that finished
-     * @param  {String}   config.url          Target url
-     * @param  {Number}   [config.pipelineId] Pipeline ID
+     * @param  {Object}   config                Configuration
+     * @param  {String}   config.scmUri         The scmUri to get permissions on
+     * @param  {String}   config.sha            The sha to apply the status to
+     * @param  {String}   config.buildStatus    The build status used for figuring out the commit status to set
+     * @param  {String}   config.token          The token used to authenticate to the SCM
+     * @param  {String}   [config.jobName]      Optional name of the job that finished
+     * @param  {String}   config.url            Target url
+     * @param  {Number}   [config.pipelineId]   Pipeline ID
+     * @param  {String}   config.scmContext     The scm context name
      * @return {Promise}
      */
     updateCommitStatus(config) {
@@ -258,14 +267,15 @@ class ScmBase {
     }
 
     /**
-    * Fetch content of a file from an scm repo
-    * @method getFile
-    * @param  {Object}   config              Configuration
-    * @param  {String}   config.scmUri       The scmUri to get permissions on
-    * @param  {String}   config.path         The file in the repo to fetch
-    * @param  {String}   config.token        The token used to authenticate to the SCM
-    * @return {Promise}
-    */
+     * Fetch content of a file from an scm repo
+     * @method getFile
+     * @param  {Object}   config              Configuration
+     * @param  {String}   config.scmUri       The scmUri to get permissions on
+     * @param  {String}   config.path         The file in the repo to fetch
+     * @param  {String}   config.token        The token used to authenticate to the SCM
+     * @param  {String}   config.scmContext   The scm context name
+     * @return {Promise}
+     */
     getFile(config) {
         return validate(config, dataSchema.plugins.scm.getFile)
             .then(validConfig => this._getFile(validConfig));
@@ -276,15 +286,16 @@ class ScmBase {
     }
 
     /**
-    * Get list of objects which consists of opened PR names and its ref
-    * @method getOpenedPRs
-    * @param  {Object}   config              Configuration
-    * @param  {String}   config.scmUri       The scmUri to get opened PRs
-    * @param  {String}   config.token        The token used to authenticate to the SCM
-    * @return {Promise}
-    */
+     * Get list of objects which consists of opened PR names and its ref
+     * @method getOpenedPRs
+     * @param  {Object}   config              Configuration
+     * @param  {String}   config.scmUri       The scmUri to get opened PRs
+     * @param  {String}   config.token        The token used to authenticate to the SCM
+     * @param  {String}   config.scmContext   The scm context name
+     * @return {Promise}
+     */
     getOpenedPRs(config) {
-        return validate(config, dataSchema.plugins.scm.getCommitSha)       // includes scmUri and token
+        return validate(config, dataSchema.plugins.scm.getCommitSha)       // includes scmUri, token and scmContext
             .then(validConfig => this._getOpenedPRs(validConfig))
             .then(jobList =>
                 validate(jobList, Joi.array().items(
@@ -316,14 +327,15 @@ class ScmBase {
     /**
      * Resolve a pull request object based on the config
      * @method getPrRef
-     * @param  {Object}   config            Configuration
-     * @param  {String}   config.scmUri     The scmUri to get PR info of
-     * @param  {String}   config.token      The token used to authenticate to the SCM
-     * @param  {Integer}  config.prNum      The PR number used to fetch the PR
+     * @param  {Object}   config                Configuration
+     * @param  {String}   config.scmUri         The scmUri to get PR info of
+     * @param  {String}   config.token          The token used to authenticate to the SCM
+     * @param  {Integer}  config.prNum          The PR number used to fetch the PR
+     * @param  {String}   config.scmContext     The scm context name
      * @return {Promise}
      */
     getPrInfo(config) {
-        return validate(config, dataSchema.plugins.scm.getCommitSha)       // includes scmUri and token
+        return validate(config, dataSchema.plugins.scm.getCommitSha)       // includes scmUri, token and scmContext
              .then(validConfig => this._getPrInfo(validConfig))
              .then(pr => validate(pr, Joi.object().keys({
                  name: Joi.reach(dataSchema.models.job.base, 'name').required(),

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
   },
   "dependencies": {
     "joi": "^10.0.5",
-    "screwdriver-data-schema": "^16.9.2"
+    "screwdriver-data-schema": "^17.0.0"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -680,11 +680,10 @@ describe('index test', () => {
         it('returns error when invalid output', () => {
             instance._getScmContexts = () => 'invalid';
 
-            return instance.getScmContexts()
-                .then(assert.fail, (err) => {
-                    assert.instanceOf(err, Error);
-                    assert.equal(err.name, 'ValidationError');
-                });
+            const result = instance.getScmContexts();
+
+            assert.instanceOf(result, Error);
+            assert.equal(result.name, 'ValidationError');
         });
 
         it('returns not implemented', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -157,7 +157,8 @@ describe('index test', () => {
             config = {
                 pipeline: {
                     scmUri: 'github.com:12344567:branch',
-                    scmRepo: { name: 'screwdriver-cd/guide' }
+                    scmRepo: { name: 'screwdriver-cd/guide' },
+                    scmContext: 'github.com'
                 },
                 job: {},
                 build: {
@@ -173,7 +174,8 @@ describe('index test', () => {
                     host: 'github.com',
                     org: 'screwdriver-cd',
                     repo: 'guide',
-                    sha: '12345'
+                    sha: '12345',
+                    scmContext: 'github.com'
                 });
 
                 return Promise.resolve({ name: 'sd-checkout-code', command: 'stuff' });
@@ -193,7 +195,8 @@ describe('index test', () => {
                     org: 'screwdriver-cd',
                     repo: 'guide',
                     sha: '12345',
-                    prRef: 'abcd'
+                    prRef: 'abcd',
+                    scmContext: 'github.com'
                 });
 
                 return Promise.resolve({ name: 'sd-checkout-code', command: 'stuff' });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -663,24 +663,12 @@ describe('index test', () => {
     });
 
     describe('getScmContext', () => {
-        const config = {
-            scmUrl: 'https://github.com/screwdriver-cd/screwdriver/tree/master'
-        };
-
-        it('returns error when invalid input', () =>
-            instance.getScmContext({})
-                .then(assert.fail, (err) => {
-                    assert.instanceOf(err, Error);
-                    assert.equal(err.name, 'ValidationError');
-                })
-        );
-
         it('returns error when invalid output', () => {
-            instance._getScmContext = () => Promise.resolve({
-                invalid: 'stuff'
-            });
+            instance._getScmContext = () => Promise.resolve([
+                { invalid: 'stuff' }
+            ]);
 
-            return instance.getScmContext(config)
+            return instance.getScmContext()
                 .then(assert.fail, (err) => {
                     assert.instanceOf(err, Error);
                     assert.equal(err.name, 'ValidationError');
@@ -688,7 +676,7 @@ describe('index test', () => {
         });
 
         it('returns not implemented', () =>
-            instance.getScmContext(config)
+            instance.getScmContext()
                 .then(() => {
                     assert.fail('you will never get dis');
                 })
@@ -698,33 +686,29 @@ describe('index test', () => {
         );
     });
 
-    describe('canHandleUrl', () => {
-        const config = {
-            scmUrl: 'https://github.com/screwdriver-cd/screwdriver/tree/master'
+    describe('canHandleWebhook', () => {
+        const headers = {
+            stuff: 'foo'
+        };
+        const payload = {
+            moreStuff: 'bar'
         };
 
-        it('returns error when invalid input', () =>
-            instance.canHandleUrl({})
-                .then(assert.fail, (err) => {
-                    assert.instanceOf(err, Error);
-                    assert.equal(err.name, 'ValidationError');
-                })
-        );
-
-        it('returns error when invalid output', () => {
-            instance._canHandleUrl = () => Promise.resolve({
-                invalid: 'stuff'
+        it('returns data from underlying method', () => {
+            instance._canHandleWebhook = () => Promise.resolve({
+                type: 'pr'
             });
 
-            return instance.canHandleUrl(config)
-                .then(assert.fail, (err) => {
-                    assert.instanceOf(err, Error);
-                    assert.equal(err.name, 'ValidationError');
+            return instance.canHandleWebhook()
+                .then((output) => {
+                    assert.deepEqual(output, {
+                        type: 'pr'
+                    });
                 });
         });
 
         it('returns not implemented', () =>
-            instance.canHandleUrl(config)
+            instance.canHandleWebhook(headers, payload)
                 .then(() => {
                     assert.fail('you will never get dis');
                 })
@@ -736,37 +720,20 @@ describe('index test', () => {
 
     describe('getDisplayName', () => {
         const config = {
-            scmContext: 'github.com'
+            displayName: 'github.com'
         };
 
-        it('returns error when invalid input', () =>
-            instance.getDisplayName({})
-                .then(assert.fail, (err) => {
-                    assert.instanceOf(err, Error);
-                    assert.equal(err.name, 'ValidationError');
-                })
-        );
-
-        it('returns error when invalid output', () => {
-            instance._getDisplayName = () => Promise.resolve({
-                invalid: 'stuff'
-            });
-
-            return instance.getDisplayName(config)
-                .then(assert.fail, (err) => {
-                    assert.instanceOf(err, Error);
-                    assert.equal(err.name, 'ValidationError');
-                });
+        beforeEach(() => {
+            instance.configure(config);
         });
 
-        it('returns not implemented', () =>
-            instance.getDisplayName(config)
-                .then(() => {
-                    assert.fail('you will never get dis');
-                })
-                .catch((err) => {
-                    assert.equal(err, 'Not implemented');
-                })
-        );
+        it('returns empty display name if no configuration', () => {
+            instance.configure({});
+            assert.equal(instance.getDisplayName(), '');
+        });
+
+        it('returns valid display name', () => {
+            assert.equal(instance.getDisplayName(), 'github.com');
+        });
     });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -663,12 +663,24 @@ describe('index test', () => {
     });
 
     describe('getScmContext', () => {
+        const config = {
+            scmUrl: 'https://github.com/screwdriver-cd/screwdriver/tree/master'
+        };
+
+        it('returns error when invalid input', () =>
+            instance.getScmContext({})
+                .then(assert.fail, (err) => {
+                    assert.instanceOf(err, Error);
+                    assert.equal(err.name, 'ValidationError');
+                })
+        );
+
         it('returns error when invalid output', () => {
             instance._getScmContext = () => Promise.resolve({
                 invalid: 'stuff'
             });
 
-            return instance.getScmContext()
+            return instance.getScmContext(config)
                 .then(assert.fail, (err) => {
                     assert.instanceOf(err, Error);
                     assert.equal(err.name, 'ValidationError');
@@ -676,7 +688,7 @@ describe('index test', () => {
         });
 
         it('returns not implemented', () =>
-            instance.getScmContext()
+            instance.getScmContext(config)
                 .then(() => {
                     assert.fail('you will never get dis');
                 })
@@ -688,7 +700,7 @@ describe('index test', () => {
 
     describe('canHandleUrl', () => {
         const config = {
-            scmUri: 'github.com:repoId:branch'
+            scmUrl: 'https://github.com/screwdriver-cd/screwdriver/tree/master'
         };
 
         it('returns error when invalid input', () =>
@@ -713,6 +725,42 @@ describe('index test', () => {
 
         it('returns not implemented', () =>
             instance.canHandleUrl(config)
+                .then(() => {
+                    assert.fail('you will never get dis');
+                })
+                .catch((err) => {
+                    assert.equal(err, 'Not implemented');
+                })
+        );
+    });
+
+    describe('getDisplayName', () => {
+        const config = {
+            scmContext: 'github.com'
+        };
+
+        it('returns error when invalid input', () =>
+            instance.getDisplayName({})
+                .then(assert.fail, (err) => {
+                    assert.instanceOf(err, Error);
+                    assert.equal(err.name, 'ValidationError');
+                })
+        );
+
+        it('returns error when invalid output', () => {
+            instance._getDisplayName = () => Promise.resolve({
+                invalid: 'stuff'
+            });
+
+            return instance.getDisplayName(config)
+                .then(assert.fail, (err) => {
+                    assert.instanceOf(err, Error);
+                    assert.equal(err.name, 'ValidationError');
+                });
+        });
+
+        it('returns not implemented', () =>
+            instance.getDisplayName(config)
                 .then(() => {
                     assert.fail('you will never get dis');
                 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -663,27 +663,13 @@ describe('index test', () => {
     });
 
     describe('getScmContexts', () => {
-        it('returns error when invalid output', () => {
-            instance._getScmContexts = () => Promise.resolve([
-                { invalid: 'stuff' }
-            ]);
-
-            return instance.getScmContexts()
-                .then(assert.fail, (err) => {
-                    assert.instanceOf(err, Error);
-                    assert.equal(err.name, 'ValidationError');
-                });
+        it('returns not implemented', () => {
+            try {
+                instance.getScmContexts();
+            } catch (err) {
+                assert.equal(err.message, 'Not implemented');
+            }
         });
-
-        it('returns not implemented', () =>
-            instance.getScmContexts()
-                .then(() => {
-                    assert.fail('you will never get dis');
-                })
-                .catch((err) => {
-                    assert.equal(err, 'Not implemented');
-                })
-        );
     });
 
     describe('canHandleWebhook', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -34,7 +34,7 @@ describe('index test', () => {
         const config = {
             checkoutUrl: 'git@github.com:screwdriver-cd/scm-base.git',
             token: 'bar',
-            scmContext: 'github.com'
+            scmContext: 'github:github.com'
         };
 
         it('returns error when invalid config object', () =>
@@ -112,7 +112,7 @@ describe('index test', () => {
             org: 'screwdriver-cd',
             repo: 'guide',
             sha: '12345',
-            scmContext: 'github.com'
+            scmContext: 'github:github.com'
         };
 
         it('returns error when invalid config object', () =>
@@ -160,7 +160,7 @@ describe('index test', () => {
                 pipeline: {
                     scmUri: 'github.com:12344567:branch',
                     scmRepo: { name: 'screwdriver-cd/guide' },
-                    scmContext: 'github.com'
+                    scmContext: 'github:github.com'
                 },
                 job: {},
                 build: {
@@ -177,7 +177,7 @@ describe('index test', () => {
                     org: 'screwdriver-cd',
                     repo: 'guide',
                     sha: '12345',
-                    scmContext: 'github.com'
+                    scmContext: 'github:github.com'
                 });
 
                 return Promise.resolve({ name: 'sd-checkout-code', command: 'stuff' });
@@ -198,7 +198,7 @@ describe('index test', () => {
                     repo: 'guide',
                     sha: '12345',
                     prRef: 'abcd',
-                    scmContext: 'github.com'
+                    scmContext: 'github:github.com'
                 });
 
                 return Promise.resolve({ name: 'sd-checkout-code', command: 'stuff' });
@@ -216,7 +216,7 @@ describe('index test', () => {
         const config = {
             scmUri: 'github.com:repoId:branch',
             token: 'token',
-            scmContext: 'github.com'
+            scmContext: 'github:github.com'
         };
 
         it('returns error when invalid config object', () =>
@@ -261,7 +261,7 @@ describe('index test', () => {
             sha: '0264b13de9aa293b7abc8cf36793b6458c07af38',
             scmUri: 'github.com:repoId:branch',
             token: 'token',
-            scmContext: 'github.com'
+            scmContext: 'github:github.com'
         };
 
         it('returns error when invalid config object', () =>
@@ -305,7 +305,7 @@ describe('index test', () => {
         const config = {
             username: 'd2lam',
             token: 'token',
-            scmContext: 'github.com'
+            scmContext: 'github:github.com'
         };
 
         it('returns error when invalid config object', () =>
@@ -349,7 +349,7 @@ describe('index test', () => {
         const config = {
             scmUri: 'github.com:repoId:branch',
             token: 'token',
-            scmContext: 'github.com'
+            scmContext: 'github:github.com'
         };
 
         it('returns error when invalid config object', () =>
@@ -393,7 +393,7 @@ describe('index test', () => {
         const config = {
             scmUri: 'github.com:repoId:branch',
             token: 'token',
-            scmContext: 'github.com'
+            scmContext: 'github:github.com'
         };
 
         it('returns error when invalid config object', () =>
@@ -441,7 +441,7 @@ describe('index test', () => {
             token: 'token',
             url: 'https://foo.bar',
             pipelineId: 123,
-            scmContext: 'github.com'
+            scmContext: 'github:github.com'
         };
 
         it('returns error when invalid config object', () =>
@@ -492,7 +492,7 @@ describe('index test', () => {
             scmUri: 'github.com:repoId:branch',
             path: 'testFile',
             token: 'token',
-            scmContext: 'github.com'
+            scmContext: 'github:github.com'
         };
 
         it('returns error when invalid config object', () =>
@@ -535,7 +535,8 @@ describe('index test', () => {
     describe('getOpenedPRs', () => {
         const config = {
             scmUri: 'github.com:repoId:branch',
-            token: 'token'
+            token: 'token',
+            scmContext: 'github:github.com'
         };
 
         it('returns error when invalid input', () =>
@@ -604,7 +605,7 @@ describe('index test', () => {
             scmUri: 'github.com:20161206:branch',
             token: 'token',
             webhookUrl: 'https://bob.by/ford',
-            scmContext: 'github.com'
+            scmContext: 'github:github.com'
         };
 
         it('returns data from underlying method', () => {
@@ -615,7 +616,8 @@ describe('index test', () => {
             return instance.addWebhook({
                 scmUri: 'github.com:20161206:branch',
                 token: 'token',
-                webhookUrl: 'https://bob.by/ford'
+                webhookUrl: 'https://bob.by/ford',
+                scmContext: 'github:github.com'
             }).then((result) => {
                 assert.strictEqual(result, expectedOutput);
             });
@@ -642,7 +644,7 @@ describe('index test', () => {
             scmUri: 'github.com:repoId:branch',
             token: 'token',
             prNum: 123,
-            scmContext: 'github.com'
+            scmContext: 'github:github.com'
         };
 
         it('returns error when invalid input', () =>

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -663,6 +663,16 @@ describe('index test', () => {
     });
 
     describe('getScmContexts', () => {
+        it('returns error when invalid output', () => {
+            instance._getScmContexts = () => 'invalid';
+
+            return instance.getScmContexts()
+                .then(assert.fail, (err) => {
+                    assert.instanceOf(err, Error);
+                    assert.equal(err.name, 'ValidationError');
+                });
+        });
+
         it('returns not implemented', () => {
             try {
                 instance.getScmContexts();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -682,10 +682,11 @@ describe('index test', () => {
         it('returns error when invalid output', () => {
             instance._getScmContexts = () => 'invalid';
 
-            const result = instance.getScmContexts();
-
-            assert.instanceOf(result, Error);
-            assert.equal(result.name, 'ValidationError');
+            return instance.getScmContexts()
+                .then(assert.fail, (err) => {
+                    assert.instanceOf(err, Error);
+                    assert.equal(err.name, 'ValidationError');
+                });
         });
 
         it('returns not implemented', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -682,11 +682,10 @@ describe('index test', () => {
         it('returns error when invalid output', () => {
             instance._getScmContexts = () => 'invalid';
 
-            return instance.getScmContexts()
-                .then(assert.fail, (err) => {
-                    assert.instanceOf(err, Error);
-                    assert.equal(err.name, 'ValidationError');
-                });
+            const result = instance.getScmContexts();
+
+            assert.instanceOf(result, Error);
+            assert.equal(result.name, 'ValidationError');
         });
 
         it('returns not implemented', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -662,13 +662,13 @@ describe('index test', () => {
         );
     });
 
-    describe('getScmContext', () => {
+    describe('getScmContexts', () => {
         it('returns error when invalid output', () => {
-            instance._getScmContext = () => Promise.resolve([
+            instance._getScmContexts = () => Promise.resolve([
                 { invalid: 'stuff' }
             ]);
 
-            return instance.getScmContext()
+            return instance.getScmContexts()
                 .then(assert.fail, (err) => {
                     assert.instanceOf(err, Error);
                     assert.equal(err.name, 'ValidationError');
@@ -676,7 +676,7 @@ describe('index test', () => {
         });
 
         it('returns not implemented', () =>
-            instance.getScmContext()
+            instance.getScmContexts()
                 .then(() => {
                     assert.fail('you will never get dis');
                 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -661,4 +661,64 @@ describe('index test', () => {
                 })
         );
     });
+
+    describe('getScmContext', () => {
+        it('returns error when invalid output', () => {
+            instance._getScmContext = () => Promise.resolve({
+                invalid: 'stuff'
+            });
+
+            return instance.getScmContext()
+                .then(assert.fail, (err) => {
+                    assert.instanceOf(err, Error);
+                    assert.equal(err.name, 'ValidationError');
+                });
+        });
+
+        it('returns not implemented', () =>
+            instance.getScmContext()
+                .then(() => {
+                    assert.fail('you will never get dis');
+                })
+                .catch((err) => {
+                    assert.equal(err, 'Not implemented');
+                })
+        );
+    });
+
+    describe('canHandleUrl', () => {
+        const config = {
+            scmUri: 'github.com:repoId:branch'
+        };
+
+        it('returns error when invalid input', () =>
+            instance.canHandleUrl({})
+                .then(assert.fail, (err) => {
+                    assert.instanceOf(err, Error);
+                    assert.equal(err.name, 'ValidationError');
+                })
+        );
+
+        it('returns error when invalid output', () => {
+            instance._canHandleUrl = () => Promise.resolve({
+                invalid: 'stuff'
+            });
+
+            return instance.canHandleUrl(config)
+                .then(assert.fail, (err) => {
+                    assert.instanceOf(err, Error);
+                    assert.equal(err.name, 'ValidationError');
+                });
+        });
+
+        it('returns not implemented', () =>
+            instance.canHandleUrl(config)
+                .then(() => {
+                    assert.fail('you will never get dis');
+                })
+                .catch((err) => {
+                    assert.equal(err, 'Not implemented');
+                })
+        );
+    });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -33,7 +33,8 @@ describe('index test', () => {
     describe('parseUrl', () => {
         const config = {
             checkoutUrl: 'git@github.com:screwdriver-cd/scm-base.git',
-            token: 'bar'
+            token: 'bar',
+            scmContext: 'github.com'
         };
 
         it('returns error when invalid config object', () =>
@@ -110,7 +111,8 @@ describe('index test', () => {
             host: 'github.com',
             org: 'screwdriver-cd',
             repo: 'guide',
-            sha: '12345'
+            sha: '12345',
+            scmContext: 'github.com'
         };
 
         it('returns error when invalid config object', () =>
@@ -213,7 +215,8 @@ describe('index test', () => {
     describe('decorateUrl', () => {
         const config = {
             scmUri: 'github.com:repoId:branch',
-            token: 'token'
+            token: 'token',
+            scmContext: 'github.com'
         };
 
         it('returns error when invalid config object', () =>
@@ -257,7 +260,8 @@ describe('index test', () => {
         const config = {
             sha: '0264b13de9aa293b7abc8cf36793b6458c07af38',
             scmUri: 'github.com:repoId:branch',
-            token: 'token'
+            token: 'token',
+            scmContext: 'github.com'
         };
 
         it('returns error when invalid config object', () =>
@@ -300,7 +304,8 @@ describe('index test', () => {
     describe('decorateAuthor', () => {
         const config = {
             username: 'd2lam',
-            token: 'token'
+            token: 'token',
+            scmContext: 'github.com'
         };
 
         it('returns error when invalid config object', () =>
@@ -343,7 +348,8 @@ describe('index test', () => {
     describe('getPermissons', () => {
         const config = {
             scmUri: 'github.com:repoId:branch',
-            token: 'token'
+            token: 'token',
+            scmContext: 'github.com'
         };
 
         it('returns error when invalid config object', () =>
@@ -386,7 +392,8 @@ describe('index test', () => {
     describe('getCommitSha', () => {
         const config = {
             scmUri: 'github.com:repoId:branch',
-            token: 'token'
+            token: 'token',
+            scmContext: 'github.com'
         };
 
         it('returns error when invalid config object', () =>
@@ -433,7 +440,8 @@ describe('index test', () => {
             buildStatus: 'SUCCESS',
             token: 'token',
             url: 'https://foo.bar',
-            pipelineId: 123
+            pipelineId: 123,
+            scmContext: 'github.com'
         };
 
         it('returns error when invalid config object', () =>
@@ -483,7 +491,8 @@ describe('index test', () => {
         const config = {
             scmUri: 'github.com:repoId:branch',
             path: 'testFile',
-            token: 'token'
+            token: 'token',
+            scmContext: 'github.com'
         };
 
         it('returns error when invalid config object', () =>
@@ -594,7 +603,8 @@ describe('index test', () => {
         const config = {
             scmUri: 'github.com:20161206:branch',
             token: 'token',
-            webhookUrl: 'https://bob.by/ford'
+            webhookUrl: 'https://bob.by/ford',
+            scmContext: 'github.com'
         };
 
         it('returns data from underlying method', () => {
@@ -631,7 +641,8 @@ describe('index test', () => {
         const config = {
             scmUri: 'github.com:repoId:branch',
             token: 'token',
-            prNum: 123
+            prNum: 123,
+            scmContext: 'github.com'
         };
 
         it('returns error when invalid input', () =>


### PR DESCRIPTION
This PR adds `getScmContext` and `canHandleUrl` function to scm-base for the multiple scm feature. 
Also, I added these documents and `_getPrInfo` document (it did not exist).

Related: https://github.com/screwdriver-cd/screwdriver/issues/365#issuecomment-313277401

Before merging for test success: https://github.com/screwdriver-cd/data-schema/pull/155