### PR TITLE
fix: update README. BREAKING CHANGE: bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Scm Base
 [![Version][npm-image]][npm-url] ![Downloads][downloads-image] [![Build Status][status-image]][status-url] [![Open Issues][issues-image]][issues-url] [![Dependency Status][daviddm-image]][daviddm-url] ![License][license-image]
 
-> Base class for defining the behavior between screwdriver and source control management systems
+> Base class for defining the behavior between Screwdriver and source control management systems
 
 ## Usage
 


### PR DESCRIPTION
Semantic release failed to determine the version for the last commit, which is a major version bump. Bump version here.