### PR TITLE
fix: reject with error

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ class ScmBase {
     }
 
     _addWebhook() {
-        return Promise.reject('Not implemented');
+        return Promise.reject(new Error('Not implemented'));
     }
 
     /**
@@ -75,7 +75,7 @@ class ScmBase {
     }
 
     _parseUrl() {
-        return Promise.reject('Not implemented');
+        return Promise.reject(new Error('Not implemented'));
     }
 
     /**
@@ -90,7 +90,7 @@ class ScmBase {
     }
 
     _parseHook() {
-        return Promise.reject('Not implemented');
+        return Promise.reject(new Error('Not implemented'));
     }
 
     /**
@@ -114,7 +114,7 @@ class ScmBase {
     }
 
     _getCheckoutCommand() {
-        return Promise.reject('Not implemented');
+        return Promise.reject(new Error('Not implemented'));
     }
 
     /**
@@ -160,7 +160,7 @@ class ScmBase {
     }
 
     _decorateUrl() {
-        return Promise.reject('Not implemented');
+        return Promise.reject(new Error('Not implemented'));
     }
 
     /**
@@ -180,7 +180,7 @@ class ScmBase {
     }
 
     _decorateCommit() {
-        return Promise.reject('Not implemented');
+        return Promise.reject(new Error('Not implemented'));
     }
 
     /**
@@ -199,7 +199,7 @@ class ScmBase {
     }
 
     _decorateAuthor() {
-        return Promise.reject('Not implemented');
+        return Promise.reject(new Error('Not implemented'));
     }
 
     /**
@@ -217,7 +217,7 @@ class ScmBase {
     }
 
     _getPermissions() {
-        return Promise.reject('Not implemented');
+        return Promise.reject(new Error('Not implemented'));
     }
 
     /**
@@ -236,7 +236,7 @@ class ScmBase {
     }
 
     _getCommitSha() {
-        return Promise.reject('Not implemented');
+        return Promise.reject(new Error('Not implemented'));
     }
 
     /**
@@ -259,7 +259,7 @@ class ScmBase {
     }
 
     _updateCommitStatus() {
-        return Promise.reject('Not implemented');
+        return Promise.reject(new Error('Not implemented'));
     }
 
     /**
@@ -278,7 +278,7 @@ class ScmBase {
     }
 
     _getFile() {
-        return Promise.reject('Not implemented');
+        return Promise.reject(new Error('Not implemented'));
     }
 
     /**
@@ -304,7 +304,7 @@ class ScmBase {
     }
 
     _getOpenedPRs() {
-        return Promise.reject('Not implemented');
+        return Promise.reject(new Error('Not implemented'));
     }
 
     /**
@@ -317,7 +317,7 @@ class ScmBase {
     }
 
     _getBellConfiguration() {
-        return Promise.reject('Not implemented');
+        return Promise.reject(new Error('Not implemented'));
     }
 
     /**
@@ -342,7 +342,7 @@ class ScmBase {
     }
 
     _getPrInfo() {
-        return Promise.reject('Not implemented');
+        return Promise.reject(new Error('Not implemented'));
     }
 
     /**
@@ -384,7 +384,7 @@ class ScmBase {
     }
 
     _canHandleWebhook() {
-        return Promise.reject('Not implemented');
+        return Promise.reject(new Error('Not implemented'));
     }
 
     /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -69,7 +69,7 @@ describe('index test', () => {
                     assert.fail('you will never get dis');
                 })
                 .catch((err) => {
-                    assert.equal(err, 'Not implemented');
+                    assert.equal(err.message, 'Not implemented');
                 })
         );
     });
@@ -100,7 +100,7 @@ describe('index test', () => {
                 .then(() => {
                     assert.fail('This should not fail the test');
                 }, (err) => {
-                    assert.equal(err, 'Not implemented');
+                    assert.equal(err.message, 'Not implemented');
                 })
         );
     });
@@ -147,7 +147,7 @@ describe('index test', () => {
                     assert.fail('you will never get dis');
                 })
                 .catch((err) => {
-                    assert.equal(err, 'Not implemented');
+                    assert.equal(err.message, 'Not implemented');
                 })
         );
     });
@@ -251,7 +251,7 @@ describe('index test', () => {
                     assert.fail('you will never get dis');
                 })
                 .catch((err) => {
-                    assert.equal(err, 'Not implemented');
+                    assert.equal(err.message, 'Not implemented');
                 })
         );
     });
@@ -296,7 +296,7 @@ describe('index test', () => {
                     assert.fail('you will never get dis');
                 })
                 .catch((err) => {
-                    assert.equal(err, 'Not implemented');
+                    assert.equal(err.message, 'Not implemented');
                 })
         );
     });
@@ -340,7 +340,7 @@ describe('index test', () => {
                     assert.fail('you will never get dis');
                 })
                 .catch((err) => {
-                    assert.equal(err, 'Not implemented');
+                    assert.equal(err.message, 'Not implemented');
                 })
         );
     });
@@ -384,7 +384,7 @@ describe('index test', () => {
                     assert.fail('you will never get dis');
                 })
                 .catch((err) => {
-                    assert.equal(err, 'Not implemented');
+                    assert.equal(err.message, 'Not implemented');
                 })
         );
     });
@@ -428,7 +428,7 @@ describe('index test', () => {
                     assert.fail('you will never get dis');
                 })
                 .catch((err) => {
-                    assert.equal(err, 'Not implemented');
+                    assert.equal(err.message, 'Not implemented');
                 })
         );
     });
@@ -476,7 +476,7 @@ describe('index test', () => {
                     assert.fail('you will never get dis');
                 })
                 .catch((err) => {
-                    assert.equal(err, 'Not implemented');
+                    assert.equal(err.message, 'Not implemented');
                 })
         );
     });
@@ -527,7 +527,7 @@ describe('index test', () => {
                     assert.fail('you will never get dis');
                 })
                 .catch((err) => {
-                    assert.equal(err, 'Not implemented');
+                    assert.equal(err.message, 'Not implemented');
                 })
         );
     });
@@ -562,7 +562,7 @@ describe('index test', () => {
         it('returns not implemented', () =>
             instance.getOpenedPRs(config)
                 .then(assert.fail, (err) => {
-                    assert.equal(err, 'Not implemented');
+                    assert.equal(err.message, 'Not implemented');
                 })
         );
 
@@ -595,7 +595,7 @@ describe('index test', () => {
                     assert.fail('you will never get dis');
                 })
                 .catch((err) => {
-                    assert.equal(err, 'Not implemented');
+                    assert.equal(err.message, 'Not implemented');
                 })
         );
     });
@@ -634,7 +634,7 @@ describe('index test', () => {
         it('rejects when not implemented', () =>
             instance.addWebhook(config)
                .then(assert.fail, (err) => {
-                   assert.strictEqual(err, 'Not implemented');
+                   assert.strictEqual(err.message, 'Not implemented');
                })
         );
     });
@@ -673,7 +673,7 @@ describe('index test', () => {
                     assert.fail('you will never get dis');
                 })
                 .catch((err) => {
-                    assert.equal(err, 'Not implemented');
+                    assert.equal(err.message, 'Not implemented');
                 })
         );
     });
@@ -724,7 +724,7 @@ describe('index test', () => {
                     assert.fail('you will never get dis');
                 })
                 .catch((err) => {
-                    assert.equal(err, 'Not implemented');
+                    assert.equal(err.message, 'Not implemented');
                 })
         );
     });


### PR DESCRIPTION
Reject with error object instead of string.

This is giving us problem when we catch the err in the API and try to wrap it with boom.wrap(err). boom.wrap assumes err is an error object.
https://github.com/hapijs/boom#wraperror-statuscode-message