### PR TITLE
fix: update joi

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "jenkins-mocha": "^4.0.0"
   },
   "dependencies": {
-    "joi": "^10.0.5",
+    "joi": "^13.0.0",
     "screwdriver-data-schema": "^18.0.0"
   }
 }


### PR DESCRIPTION
Needs this since data-schema is using `13.0.0` and this is breaking `scm-github` pipeline
https://cd.screwdriver.cd/pipelines/8/builds/16574