### PR TITLE
[DNM] feat(1132): Pass parent pipeline to getCheckoutCommand

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,6 +172,15 @@ class ScmBase {
             checkoutConfig.commitBranch = o.build.commitBranch;
         }
 
+        if (o.configPipeline) {
+            const parentConfig = { sha: o.configPipelineSha };
+
+            [parentConfig.host, , parentConfig.branch] = o.configPipeline.scmUri.split(':');
+            [parentConfig.org, parentConfig.repo] = o.configPipeline.scmRepo.name.split('/');
+
+            checkoutConfig.parentConfig = parentConfig;
+        }
+
         const manifest = getAnnotations(o.job.permutations[0], repoManifestAnnotation);
 
         if (manifest) {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "jenkins-mocha": "^4.0.0"
   },
   "dependencies": {
-    "joi": "^13.0.0",
-    "screwdriver-data-schema": "^18.13.3"
+    "joi": "^13.4.0",
+    "screwdriver-data-schema": "^18.27.0"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -304,6 +304,39 @@ describe('index test', () => {
                     assert.equal(command, 'stuff');
                 });
         });
+
+        it('returns a command for parent config', () => {
+            instance._getCheckoutCommand = (o) => {
+                assert.deepEqual(o, {
+                    branch: 'branch',
+                    host: 'github.com',
+                    org: 'screwdriver-cd',
+                    repo: 'guide',
+                    sha: '12345',
+                    scmContext: 'github:github.com',
+                    parentConfig: {
+                        branch: 'master',
+                        host: 'github.com',
+                        org: 'screwdriver-cd',
+                        repo: 'parent-to-guide',
+                        sha: '54321'
+                    }
+                });
+
+                return Promise.resolve({ name: 'sd-checkout-code', command: 'stuff' });
+            };
+            config.configPipeline = {
+                scmUri: 'github.com:12344567:master',
+                scmRepo: { name: 'screwdriver-cd/parent-to-guide' },
+                scmContext: 'github:github.com'
+            };
+            config.configPipelineSha = '54321';
+
+            return instance.getSetupCommand(config)
+                .then((command) => {
+                    assert.equal(command, 'stuff');
+                });
+        });
     });
 
     describe('decorateUrl', () => {


### PR DESCRIPTION
## Context
`getCheckoutCommand` needs the parent pipeline model in order to clone its repository.

## Objective
Pass parent pipeline to `getCheckoutCommand`

## References
Pending:
  - https://github.com/screwdriver-cd/data-schema/pull/260
  - https://github.com/screwdriver-cd/models/pull/270

https://github.com/screwdriver-cd/screwdriver/issues/1132