### PR TITLE
fix(1440): Update documentation for updateCommitStatus [2]

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,13 +294,15 @@ The parameters required are:
 | :-------------   | :---- | :------- | :-------------|
 | config        | Object | Yes | Configuration Object |
 | config.buildStatus | String | Yes | The screwdriver build status to translate into scm commit status |
+| config.context | String | No | The status context |
+| config.description | String | No | The status description |
 | config.jobName | String | No | Optional name of the job that finished |
+| config.pipelineId | Number | No | The pipeline id |
+| config.scmContext | String | No | The name of scm context |
 | config.scmUri | String | Yes | The scm uri (ex: `github.com:1234:branchName`) |
 | config.sha | String | Yes | The scm sha to update a status for |
 | config.token | String | Yes | Access token for scm |
 | config.url | String | No | The target url for setting up details |
-| config.pipelineId | Number | No | The pipeline id |
-| config.scmContext | String | No | The name of scm context |
 
 #### Expected Outcome
 Update the commit status for a given repository and sha.

--- a/index.js
+++ b/index.js
@@ -315,7 +315,9 @@ class ScmBase {
      * @param  {String}   [config.jobName]        Optional name of the job that finished
      * @param  {String}   config.url              Target url
      * @param  {Number}   [config.pipelineId]     Pipeline ID
-     * @param  {String}   [config.scmContext]     The scm context name
+     * @param  {String}   [config.scmContext]     The SCM context name
+     * @param  {String}   [config.context]        The context of the status
+     * @param  {String}   [config.description]    The description of the status
      * @return {Promise}
      */
     updateCommitStatus(config) {


### PR DESCRIPTION
## Context
Users would like to add custom Git statuses for commits.

## Objective
This PR adds documentation for `context` and `description` fields to be passed into the `scm.updateCommitStatus` method. The `context` will be the key provided by the user. `description` will be the message they want to show.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1440