### PR TITLE
feat(823): [2] add getCommitRefSha()

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,25 @@ The commit sha for a given branch on a repository.
 1. Resolve with a commit sha string for the given `scmUri`
 2. Reject if not able to get a sha
 
+### getCommitRefSha
+Required parameters:
+
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| config        | Object | Configuration Object |
+| config.token | String | Access token for scm |
+| config.owner | String | Owner of target repository |
+| config.repo | String | Target repository |
+| config.ref | String | Reference of the commit |
+| config.scmContext | String | (optional) The name of scm context |
+
+#### Expected Outcome
+The commit sha for a ref on a repository.
+
+#### Expected Promise response
+1. Resolve with a commit sha string for the given `owner`, `repo` and `ref`
+2. Reject if not able to get a sha
+
 ### updateCommitStatus
 The parameters required are:
 

--- a/index.js
+++ b/index.js
@@ -308,11 +308,12 @@ class ScmBase {
      * Get a commit sha from a reference
      * @method getCommitRefSha
      * @param  {Object}   config
-     * @param  {String}   config.token     The token used to authenticate to the SCM
-     * @param  {String}   config.owner     The owner of the target repository
-     * @param  {String}   config.repo      The target repository name
-     * @param  {String}   config.ref       The reference which we want
-     * @return {Promise}                   Resolves to the commit sha
+     * @param  {String}   config.token         The token used to authenticate to the SCM
+     * @param  {String}   config.owner         The owner of the target repository
+     * @param  {String}   config.repo          The target repository name
+     * @param  {String}   config.ref           The reference which we want
+     * @param  {String}   [config.scmContext]  The scm context name
+     * @return {Promise}                       Resolves to the commit sha
      */
     getCommitRefSha(config) {
         return validate(config, dataSchema.plugins.scm.getCommitRefSha)

--- a/index.js
+++ b/index.js
@@ -305,6 +305,25 @@ class ScmBase {
     }
 
     /**
+     * Get a commit sha from a reference
+     * @method getCommitRefSha
+     * @param  {Object}   config
+     * @param  {String}   config.token     The token used to authenticate to the SCM
+     * @param  {String}   config.owner     The owner of the target repository
+     * @param  {String}   config.repo      The target repository name
+     * @param  {String}   config.ref       The reference which we want
+     * @return {Promise}                   Resolves to the commit sha
+     */
+    getCommitRefSha(config) {
+        return validate(config, dataSchema.plugins.scm.getCommitRefSha)
+            .then(validConfig => this._getCommitRefSha(validConfig));
+    }
+
+    _getCommitRefSha() {
+        return Promise.reject(new Error('Not implemented'));
+    }
+
+    /**
      * Update the commit status for a given repo and sha
      * @method updateCommitStatus
      * @param  {Object}   config                  Configuration

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "chai": "^3.5.0",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.0",
-    "jenkins-mocha": "^6.0.0"
+    "jenkins-mocha": "^7.0.0"
   },
   "dependencies": {
     "joi": "^13.4.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -605,6 +605,50 @@ describe('index test', () => {
         );
     });
 
+    describe('getCommitRefSha', () => {
+        const config = {
+            token,
+            owner: 'owner',
+            repo: 'repo',
+            ref: 'master'
+        };
+
+        it('returns error when invalid config object', () =>
+            instance.getCommitRefSha({})
+                .then(() => {
+                    assert.fail('you will never get dis');
+                })
+                .catch((err) => {
+                    assert.instanceOf(err, Error);
+                    assert.equal(err.name, 'ValidationError');
+                })
+        );
+
+        it('returns error when invalid output', () => {
+            instance._getCommitRefSha = () => Promise.resolve({
+                invalid: 'object'
+            });
+
+            return instance.getCommitRefSha(config)
+                .then(() => {
+                    assert.fail('you will never get dis');
+                })
+                .catch((err) => {
+                    assert.instanceOf(err, Error);
+                    assert.equal(err.name, 'AssertionError');
+                });
+        });
+
+        it('returns not implemented', () =>
+            instance.getCommitRefSha(config)
+                .then(() => {
+                    assert.fail('you will never get dis');
+                })
+                .catch((err) => {
+                    assert.equal(err.message, 'Not implemented');
+                })
+        );
+    });
     describe('updateCommitStatus', () => {
         const config = {
             scmUri: 'github.com:repoId:branch',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -610,7 +610,8 @@ describe('index test', () => {
             token,
             owner: 'owner',
             repo: 'repo',
-            ref: 'master'
+            ref: 'master',
+            scmContext: 'github:github.com'
         };
 
         it('returns error when invalid config object', () =>


### PR DESCRIPTION
This PR creates the interface of [getCommitRefSha](https://octokit.github.io/rest.js/#api-Repos-getCommitRefSha).
It's used for getting `sha` when `release` and `tag` triggers are fired.

Related Issue: https://github.com/screwdriver-cd/screwdriver/issues/823
Blocked By: https://github.com/screwdriver-cd/data-schema/pull/322