### PR TITLE
fix(1455): Add rootDir to getCheckoutCommand and parseUrl (3.5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log
 .DS_STORE
 .*.swp
 .nyc_output/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Required parameters:
 An scmUri (ex: `github.com:1234:branchName`, where 1234 is a repo ID number), which will be a unique identifier for the repo and branch in Screwdriver.
 
 #### Expected Promise response
-1. Resolve with an scm uri for the repository (e.g.: github.com:12345:master:src/app/component)
+1. Resolve with an scm uri for the repository (e.g.: github.com:12345:master or github.com:12345:master:src/app/component)
 2. Reject if not able to parse url
 
 ### parseHook

--- a/README.md
+++ b/README.md
@@ -42,14 +42,15 @@ Required parameters:
 | :-------------   | :---- | :-------------|
 | config             | Object | Configuration Object |
 | config.checkoutUrl | String | Checkout url for a repo to parse |
-| config.token  | String | Access token for scm |
+| config.rootDir | String | (optional) Root directory where source code lives (ex: src/app/component) |
 | config.scmContext | String | (optional) The name of scm context |
+| config.token  | String | Access token for scm |
 
 #### Expected Outcome
 An scmUri (ex: `github.com:1234:branchName`, where 1234 is a repo ID number), which will be a unique identifier for the repo and branch in Screwdriver.
 
 #### Expected Promise response
-1. Resolve with an scm uri for the repository
+1. Resolve with an scm uri for the repository (e.g.: github.com:12345:master:src/app/component)
 2. Reject if not able to parse url
 
 ### parseHook
@@ -115,6 +116,7 @@ Required parameters:
 | config.org | String | Yes | Scm org (ex: screwdriver-cd) |
 | config.prRef | String | No | PR branch or reference |
 | config.repo | String | Yes | Scm repo (ex: guide) |
+| config.rootDir | String | No | Root directory where source code lives (ex: src/app/component) |
 | config.sha | String | Yes | Scm sha |
 | config.scmContext | String | No | The name of scm context |
 

--- a/index.js
+++ b/index.js
@@ -69,6 +69,7 @@ class ScmBase {
      * @param  {String}    config.checkoutUrl       Url to parse
      * @param  {String}    config.token             The token used to authenticate to the SCM
      * @param  {String}    [config.scmContext]      The scm context name
+     * @param  {String}    [config.rootDir]         Root directory where source code is
      * @return {Promise}
      */
     parseUrl(config) {
@@ -130,6 +131,7 @@ class ScmBase {
      * @param  {String}    [config.scmContext]    The scm context name
      * @param  {String}    [config.prRef]         PR reference (can be a PR branch or reference)
      * @param  {String}    [config.manifest]      Repo manifest URL (only defined if `screwdriver.cd/repoManifest` annotation is)
+     * @param  {String}    [config.rootDir]       Root directory of source code
      * @return {Promise}
      */
     getCheckoutCommand(config) {
@@ -153,7 +155,7 @@ class ScmBase {
      * @return {Promise}
      */
     getSetupCommand(o) {
-        const [host, , branch] = o.pipeline.scmUri.split(':');
+        const [host, , branch, rootDir] = o.pipeline.scmUri.split(':');
         const [org, repo] = o.pipeline.scmRepo.name.split('/');
         const checkoutConfig = {
             branch,
@@ -163,6 +165,10 @@ class ScmBase {
             sha: o.build.sha,
             scmContext: o.pipeline.scmContext
         };
+
+        if (rootDir) {
+            checkoutConfig.rootDir = rootDir;
+        }
 
         if (o.build.prRef) {
             checkoutConfig.prRef = o.build.prRef;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -235,6 +235,28 @@ describe('index test', () => {
                 });
         });
 
+        it('returns a command when rootDir exists', () => {
+            config.pipeline.scmUri = 'github.com:12344567:branch:src/app/component';
+            instance._getCheckoutCommand = (o) => {
+                assert.deepEqual(o, {
+                    branch: 'branch',
+                    host: 'github.com',
+                    org: 'screwdriver-cd',
+                    repo: 'guide',
+                    rootDir: 'src/app/component',
+                    sha: '12345',
+                    scmContext: 'github:github.com'
+                });
+
+                return Promise.resolve({ name: 'sd-checkout-code', command: 'stuff' });
+            };
+
+            return instance.getSetupCommand(config)
+                .then((command) => {
+                    assert.equal(command, 'stuff');
+                });
+        });
+
         it('returns a command for pr', () => {
             instance._getCheckoutCommand = (o) => {
                 assert.deepEqual(o, {


### PR DESCRIPTION
## Context
Would be nice if users could put screwdriver.yaml not at root.

## Objective
This PR adds `rootDir` as an optional arg to `getCheckoutCommand` and `parseUrl`. Also passes `rootDir` to `getCheckoutCommand` in `getSetupCommand` if it exists.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1455