### PR TITLE
fix(1646): [2] allow getPrInfo to return baseBranch

### DIFF
--- a/index.js
+++ b/index.js
@@ -439,7 +439,8 @@ class ScmBase {
                 title: Joi.reach(dataSchema.core.scm.pr, 'title'),
                 createTime: Joi.reach(dataSchema.core.scm.pr, 'createTime'),
                 url: Joi.reach(dataSchema.core.scm.pr, 'url'),
-                userProfile: Joi.reach(dataSchema.core.scm.pr, 'userProfile')
+                userProfile: Joi.reach(dataSchema.core.scm.pr, 'userProfile'),
+                baseBranch: Joi.reach(dataSchema.core.scm.pr, 'baseBranch')
             })));
     }
 


### PR DESCRIPTION
**Issue #, if available:** https://github.com/screwdriver-cd/screwdriver/issues/1646
When `pipeline.prSync` is called, it needs base branch info for the PR to get next job for `~pr:<branchName>`.

**Description of changes:**
This PR allow `getPrInfo` to return `baseBranch` value which contains the base branch name of a PR.

This PR is requires below changes before merge.
https://github.com/screwdriver-cd/data-schema/pull/339

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of your choice and that I have the authority necessary to make this contribution on behalf of its copyright owner.
