### PR TITLE
fix: fix base branch for pr specific branch build

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,6 +157,7 @@ class ScmBase {
     getSetupCommand(o) {
         const [host, , branch, rootDir] = o.pipeline.scmUri.split(':');
         const [org, repo] = o.pipeline.scmRepo.name.split('/');
+        const prBranchRegex = /^~pr:(.*)$/;
         const checkoutConfig = {
             branch,
             host,
@@ -171,7 +172,15 @@ class ScmBase {
         }
 
         if (o.build.prRef) {
+            const match = prBranchRegex.exec(o.build.startFrom);
+
             checkoutConfig.prRef = o.build.prRef;
+
+            if (match !== null) {
+                // Overwrite base branch by pr specific branch if specified.
+                // prRef needs to be merged into the branch specified in startFrom not main branch.
+                checkoutConfig.branch = match[1];
+            }
         }
 
         if (o.build.commitBranch) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -279,6 +279,29 @@ describe('index test', () => {
                 });
         });
 
+        it('returns a command for pr branch specific build', () => {
+            instance._getCheckoutCommand = (o) => {
+                assert.deepEqual(o, {
+                    branch: 'prSpecificBranch',
+                    host: 'github.com',
+                    org: 'screwdriver-cd',
+                    repo: 'guide',
+                    sha: '12345',
+                    prRef: 'abcd',
+                    scmContext: 'github:github.com'
+                });
+
+                return Promise.resolve({ name: 'sd-checkout-code', command: 'stuff' });
+            };
+            config.build.prRef = 'abcd';
+            config.build.startFrom = '~pr:prSpecificBranch';
+
+            return instance.getSetupCommand(config)
+                .then((command) => {
+                    assert.equal(command, 'stuff');
+                });
+        });
+
         it('returns a command for manifest', () => {
             instance._getCheckoutCommand = (o) => {
                 assert.deepEqual(o, {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

There is a bug in chainPR feature.
For PR builds, scm bookend clones build's source code from each SCM, fetches pr refs and merge into the main branch of its pipeline.
But the bookend shouldn't merge the PR branch into the main branch when the build runs under PR specific branch setting because the PR on the SCM will merge into user specified branch not the main branch.

to-be:
* for `~pr` builds
```
$ git clone repo
$ git reset --hard mainBranch
$ git merge prRef
```

* for `~pr:mybranch` builds
```
$ git clone repo
$ git reset --hard mybranch
$ git merge prRef
```

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
