### PR TITLE
[3] fix(1755): Use baseBranch

### DIFF
--- a/index.js
+++ b/index.js
@@ -183,8 +183,8 @@ class ScmBase {
             }
         }
 
-        if (o.build.commitBranch) {
-            checkoutConfig.commitBranch = o.build.commitBranch;
+        if (o.build.baseBranch) {
+            checkoutConfig.commitBranch = o.build.baseBranch;
         }
 
         if (o.configPipeline) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -656,7 +656,8 @@ describe('index test', () => {
             owner: 'owner',
             repo: 'repo',
             ref: 'master',
-            scmContext: 'github:github.com'
+            scmContext: 'github:github.com',
+            refType: 'heads'
         };
 
         it('returns error when invalid config object', () =>

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -342,7 +342,7 @@ describe('index test', () => {
 
                 return Promise.resolve({ name: 'sd-checkout-code', command: 'stuff' });
             };
-            config.build.commitBranch = 'cm-branch';
+            config.build.baseBranch = 'cm-branch';
 
             return instance.getSetupCommand(config)
                 .then((command) => {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
To use branch info in the event, use baseBranch property instead of commitBranch.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Use baseBranch property instead of commitBranch.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/1755
https://github.com/screwdriver-cd/screwdriver/issues/1760

Related PRs:
https://github.com/screwdriver-cd/data-schema/pull/357
https://github.com/screwdriver-cd/models/pull/396
https://github.com/screwdriver-cd/screwdriver/pull/1770

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
