### PR TITLE
fix(965):[2] $GIT_BRANCH invalid value in PR builds 

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,6 +181,7 @@ class ScmBase {
                 // prRef needs to be merged into the branch specified in startFrom not main branch.
                 checkoutConfig.branch = match[1];
             }
+            checkoutConfig.prSource = o.build.prSource;
             checkoutConfig.prBranchName = o.build.prInfo.prBranchName;
         }
 

--- a/index.js
+++ b/index.js
@@ -181,6 +181,7 @@ class ScmBase {
                 // prRef needs to be merged into the branch specified in startFrom not main branch.
                 checkoutConfig.branch = match[1];
             }
+            checkoutConfig.prBranchName = o.build.prInfo.prBranchName;
         }
 
         if (o.build.commitBranch) {
@@ -444,6 +445,7 @@ class ScmBase {
                 name: Joi.reach(dataSchema.models.job.base, 'name').required(),
                 sha: Joi.reach(dataSchema.models.build.base, 'sha').required(),
                 ref: Joi.string().required(),
+                prBranchName: Joi.string().optional(),
                 username: Joi.reach(dataSchema.core.scm.user, 'username'),
                 title: Joi.reach(dataSchema.core.scm.pr, 'title'),
                 createTime: Joi.reach(dataSchema.core.scm.pr, 'createTime'),

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -210,7 +210,11 @@ describe('index test', () => {
                     permutations: [{}]
                 },
                 build: {
-                    sha: '12345'
+                    sha: '12345',
+                    prRef: 'prRef',
+                    prInfo: {
+                        prBranchName: 'prBranchName'
+                    }
                 }
             };
         });
@@ -263,6 +267,7 @@ describe('index test', () => {
                     branch: 'branch',
                     host: 'github.com',
                     org: 'screwdriver-cd',
+                    prBranchName: 'prBranchName',
                     repo: 'guide',
                     sha: '12345',
                     prRef: 'abcd',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -227,6 +227,8 @@ describe('index test', () => {
                     org: 'screwdriver-cd',
                     repo: 'guide',
                     sha: '12345',
+                    prBranchName: 'prBranchName',
+                    prRef: 'prRef',
                     scmContext: 'github:github.com'
                 });
 
@@ -249,6 +251,8 @@ describe('index test', () => {
                     repo: 'guide',
                     rootDir: 'src/app/component',
                     sha: '12345',
+                    prBranchName: 'prBranchName',
+                    prRef: 'prRef',
                     scmContext: 'github:github.com'
                 });
 
@@ -267,9 +271,9 @@ describe('index test', () => {
                     branch: 'branch',
                     host: 'github.com',
                     org: 'screwdriver-cd',
-                    prBranchName: 'prBranchName',
                     repo: 'guide',
                     sha: '12345',
+                    prBranchName: 'prBranchName',
                     prRef: 'abcd',
                     scmContext: 'github:github.com'
                 });
@@ -292,6 +296,7 @@ describe('index test', () => {
                     org: 'screwdriver-cd',
                     repo: 'guide',
                     sha: '12345',
+                    prBranchName: 'prBranchName',
                     prRef: 'abcd',
                     scmContext: 'github:github.com'
                 });
@@ -316,6 +321,8 @@ describe('index test', () => {
                     org: 'screwdriver-cd',
                     repo: 'guide',
                     sha: '12345',
+                    prBranchName: 'prBranchName',
+                    prRef: 'prRef',
                     scmContext: 'github:github.com'
                 });
 
@@ -341,6 +348,8 @@ describe('index test', () => {
                     org: 'screwdriver-cd',
                     repo: 'guide',
                     sha: '12345',
+                    prBranchName: 'prBranchName',
+                    prRef: 'prRef',
                     commitBranch: 'cm-branch',
                     scmContext: 'github:github.com'
                 });
@@ -363,6 +372,8 @@ describe('index test', () => {
                     org: 'screwdriver-cd',
                     repo: 'guide',
                     sha: '12345',
+                    prBranchName: 'prBranchName',
+                    prRef: 'prRef',
                     scmContext: 'github:github.com',
                     parentConfig: {
                         branch: 'master',
@@ -686,7 +697,7 @@ describe('index test', () => {
                 })
                 .catch((err) => {
                     assert.instanceOf(err, Error);
-                    assert.equal(err.name, 'AssertionError');
+                    assert.equal(err.name, 'ValidationError');
                 });
         });
 
@@ -696,7 +707,7 @@ describe('index test', () => {
                     assert.fail('you will never get dis');
                 })
                 .catch((err) => {
-                    assert.equal(err.message, 'Not implemented');
+                    assert.equal(err.message, 'AssertionError');
                 })
         );
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -212,6 +212,7 @@ describe('index test', () => {
                 build: {
                     sha: '12345',
                     prRef: 'prRef',
+                    prSource: 'branch',
                     prInfo: {
                         prBranchName: 'prBranchName'
                     }
@@ -227,6 +228,7 @@ describe('index test', () => {
                     org: 'screwdriver-cd',
                     repo: 'guide',
                     sha: '12345',
+                    prSource: 'branch',
                     prBranchName: 'prBranchName',
                     prRef: 'prRef',
                     scmContext: 'github:github.com'
@@ -251,6 +253,7 @@ describe('index test', () => {
                     repo: 'guide',
                     rootDir: 'src/app/component',
                     sha: '12345',
+                    prSource: 'branch',
                     prBranchName: 'prBranchName',
                     prRef: 'prRef',
                     scmContext: 'github:github.com'
@@ -273,6 +276,7 @@ describe('index test', () => {
                     org: 'screwdriver-cd',
                     repo: 'guide',
                     sha: '12345',
+                    prSource: 'branch',
                     prBranchName: 'prBranchName',
                     prRef: 'abcd',
                     scmContext: 'github:github.com'
@@ -296,6 +300,7 @@ describe('index test', () => {
                     org: 'screwdriver-cd',
                     repo: 'guide',
                     sha: '12345',
+                    prSource: 'branch',
                     prBranchName: 'prBranchName',
                     prRef: 'abcd',
                     scmContext: 'github:github.com'
@@ -321,6 +326,7 @@ describe('index test', () => {
                     org: 'screwdriver-cd',
                     repo: 'guide',
                     sha: '12345',
+                    prSource: 'branch',
                     prBranchName: 'prBranchName',
                     prRef: 'prRef',
                     scmContext: 'github:github.com'
@@ -348,6 +354,7 @@ describe('index test', () => {
                     org: 'screwdriver-cd',
                     repo: 'guide',
                     sha: '12345',
+                    prSource: 'branch',
                     prBranchName: 'prBranchName',
                     prRef: 'prRef',
                     commitBranch: 'cm-branch',
@@ -372,6 +379,7 @@ describe('index test', () => {
                     org: 'screwdriver-cd',
                     repo: 'guide',
                     sha: '12345',
+                    prSource: 'branch',
                     prBranchName: 'prBranchName',
                     prRef: 'prRef',
                     scmContext: 'github:github.com',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -672,7 +672,8 @@ describe('index test', () => {
             owner: 'owner',
             repo: 'repo',
             ref: 'master',
-            scmContext: 'github:github.com'
+            scmContext: 'github:github.com',
+            refType: 'heads'
         };
 
         it('returns error when invalid config object', () =>
@@ -697,7 +698,7 @@ describe('index test', () => {
                 })
                 .catch((err) => {
                     assert.instanceOf(err, Error);
-                    assert.equal(err.name, 'ValidationError');
+                    assert.equal(err.name, 'AssertionError');
                 });
         });
 
@@ -707,7 +708,7 @@ describe('index test', () => {
                     assert.fail('you will never get dis');
                 })
                 .catch((err) => {
-                    assert.equal(err.message, 'AssertionError');
+                    assert.equal(err.message, 'Not implemented');
                 })
         );
     });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
I fix issue.
I add new variables,`PR_BRANCH_NAME`

This PR is requires below changes before merge.
https://github.com/screwdriver-cd/data-schema/pull/386


## Objective
In this PR, get `prBranchName`
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
