### PR TITLE
fix: hotfix for chainPR not working

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,7 +182,9 @@ class ScmBase {
                 checkoutConfig.branch = match[1];
             }
             checkoutConfig.prSource = o.build.prSource;
-            checkoutConfig.prBranchName = o.build.prInfo.prBranchName;
+            if (o.build.prInfo) {
+                checkoutConfig.prBranchName = o.build.prInfo.prBranchName;
+            }
         }
 
         if (o.build.baseBranch) {


### PR DESCRIPTION
## Context

Chain PR is still broken after GIT_BRANCH fixes.

From OSSD API logs for https://cd.screwdriver.cd/pipelines/2539/pulls

```
200302/193823.384, (1583177902244:sdapi-84f7644d89-tgpmx:19:k7aur1l3:10977) [request,server,error] data: TypeError: Cannot read property 'prBranchName' of undefined
    at ScmRouter.getSetupCommand (/usr/src/app/node_modules/screwdriver-scm-base/index.js:185:58)
    at /usr/src/app/node_modules/screwdriver-build-bookend/index.js:122:58
    at Array.map (<anonymous>)
    at Bookend.getSetupCommands (/usr/src/app/node_modules/screwdriver-build-bookend/index.js:122:43)
    at /usr/src/app/node_modules/screwdriver-models/lib/buildFactory.js:239:38
    at async Promise.all (index 0)
```

## Objective

Temporarily fix CHAIN_PR. GIT_BRANCH not working can be addressed later.

@kumada626 @ibu1224 

## References

https://github.com/screwdriver-cd/scm-github/pull/150#issuecomment-593287415

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
