### PR TITLE
fix(2029): [1] Add prSource to prInfo return value

### DIFF
--- a/index.js
+++ b/index.js
@@ -455,7 +455,8 @@ class ScmBase {
                 url: Joi.reach(dataSchema.core.scm.pr, 'url'),
                 userProfile: Joi.reach(dataSchema.core.scm.pr, 'userProfile'),
                 baseBranch: Joi.reach(dataSchema.core.scm.pr, 'baseBranch'),
-                mergeable: Joi.boolean().allow(null)
+                mergeable: Joi.boolean().allow(null),
+                prSource: Joi.string().optional()
             })));
     }
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
When PR builds are restarted by API call, prSource information is disappear.
Because of this, restarted PR builds cannot trigger next Jobs.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
I added prSource to getPrInfo return value.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
screwdriver-cd/screwdriver#2029

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
