### PR TITLE
feat(1958): Upgrade joi dependency and dataschema. BREAKING CHANGE: hapi v19

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /* eslint-disable no-underscore-dangle */
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const dataSchema = require('screwdriver-data-schema');
 const { getAnnotations } = require('./lib/helper');
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /* eslint-disable no-underscore-dangle */
-const Joi = require('joi');
+const Joi = require('@hapi/joi');
 const dataSchema = require('screwdriver-data-schema');
 const { getAnnotations } = require('./lib/helper');
 
@@ -15,7 +15,7 @@ const repoManifestAnnotation = 'screwdriver.cd/repoManifest';
  * @return {Promise}
  */
 function validate(config, schema) {
-    const result = Joi.validate(config, schema);
+    const result = schema.validate(config);
 
     return result.error ? Promise.reject(result.error) : Promise.resolve(config);
 }
@@ -75,7 +75,7 @@ class ScmBase {
     parseUrl(config) {
         return validate(config, dataSchema.plugins.scm.parseUrl)
             .then(validUrl => this._parseUrl(validUrl))
-            .then(uri => validate(uri, Joi.reach(dataSchema.models.pipeline.base, 'scmUri')));
+            .then(uri => validate(uri, dataSchema.models.pipeline.base.extract('scmUri')));
     }
 
     _parseUrl() {
@@ -402,13 +402,13 @@ class ScmBase {
             .then(jobList =>
                 validate(jobList, Joi.array().items(
                     Joi.object().keys({
-                        name: Joi.reach(dataSchema.models.job.base, 'name').required(),
+                        name: dataSchema.models.job.base.extract('name').required(),
                         ref: Joi.string().required(),
-                        username: Joi.reach(dataSchema.core.scm.pr, 'username'),
-                        title: Joi.reach(dataSchema.core.scm.pr, 'title'),
-                        createTime: Joi.reach(dataSchema.core.scm.pr, 'createTime'),
-                        url: Joi.reach(dataSchema.core.scm.pr, 'url'),
-                        userProfile: Joi.reach(dataSchema.core.scm.pr, 'userProfile')
+                        username: dataSchema.core.scm.pr.extract('username'),
+                        title: dataSchema.core.scm.pr.extract('title'),
+                        createTime: dataSchema.core.scm.pr.extract('createTime'),
+                        url: dataSchema.core.scm.pr.extract('url'),
+                        userProfile: dataSchema.core.scm.pr.extract('userProfile')
                     })
                 ))
             );
@@ -445,16 +445,16 @@ class ScmBase {
         return validate(config, dataSchema.plugins.scm.getCommitSha) // includes scmUri, token and scmContext
             .then(validConfig => this._getPrInfo(validConfig))
             .then(pr => validate(pr, Joi.object().keys({
-                name: Joi.reach(dataSchema.models.job.base, 'name').required(),
-                sha: Joi.reach(dataSchema.models.build.base, 'sha').required(),
+                name: dataSchema.models.job.base.extract('name').required(),
+                sha: dataSchema.models.build.base.extract('sha').required(),
                 ref: Joi.string().required(),
                 prBranchName: Joi.string().optional(),
-                username: Joi.reach(dataSchema.core.scm.user, 'username'),
-                title: Joi.reach(dataSchema.core.scm.pr, 'title'),
-                createTime: Joi.reach(dataSchema.core.scm.pr, 'createTime'),
-                url: Joi.reach(dataSchema.core.scm.pr, 'url'),
-                userProfile: Joi.reach(dataSchema.core.scm.pr, 'userProfile'),
-                baseBranch: Joi.reach(dataSchema.core.scm.pr, 'baseBranch'),
+                username: dataSchema.core.scm.user.extract('username'),
+                title: dataSchema.core.scm.pr.extract('title'),
+                createTime: dataSchema.core.scm.pr.extract('createTime'),
+                url: dataSchema.core.scm.pr.extract('url'),
+                userProfile: dataSchema.core.scm.pr.extract('userProfile'),
+                baseBranch: dataSchema.core.scm.pr.extract('baseBranch'),
                 mergeable: Joi.boolean().allow(null),
                 prSource: Joi.string().optional()
             })));
@@ -480,9 +480,9 @@ class ScmBase {
             .then(validConfig => this._addPrComment(validConfig))
             .then(prComment => validate(prComment, Joi.alternatives().try(
                 Joi.object().keys({
-                    commentId: Joi.reach(dataSchema.models.job.base, 'id').required(),
-                    createTime: Joi.reach(dataSchema.models.build.base, 'createTime').required(),
-                    username: Joi.reach(dataSchema.core.scm.user, 'username').required()
+                    commentId: dataSchema.models.job.base.extract('id').required(),
+                    createTime: dataSchema.models.build.base.extract('createTime').required(),
+                    username: dataSchema.core.scm.user.extract('username').required()
                 }),
                 Joi.string().allow(null)
             )));
@@ -509,9 +509,10 @@ class ScmBase {
      */
     getScmContexts() {
         const result = this._getScmContexts();
-        const validateResult = Joi.validate(result, Joi.array().items(
-            Joi.reach(dataSchema.models.pipeline.base, 'scmContext').required()
-        ));
+        const schema = Joi.array().items(
+            dataSchema.models.pipeline.base.extract('scmContext').required()
+        );
+        const validateResult = schema.validate(result);
 
         return validateResult.error || result;
     }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "screwdriver-scm-base",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Base class for defining the behavior between screwdriver and source control management systems",
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "jenkins-mocha --recursive --timeout 3000",
+    "test": "mocha --recursive --timeout 3000",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
@@ -40,10 +40,10 @@
     "chai": "^3.5.0",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.0",
-    "jenkins-mocha": "^7.0.0"
+    "mocha": "^8.1.1"
   },
   "dependencies": {
-    "@hapi/joi": "^17.1.1",
+    "joi": "^17.2.0",
     "screwdriver-data-schema": "git://github.com/screwdriver-cd/data-schema.git#hapi-v19"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "jenkins-mocha": "^7.0.0"
   },
   "dependencies": {
-    "joi": "^13.4.0",
-    "screwdriver-data-schema": "^19.10.0"
+    "@hapi/joi": "^17.1.1",
+    "screwdriver-data-schema": "git://github.com/screwdriver-cd/data-schema.git#hapi-v19"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-scm-base",
-  "version": "5.0.0",
+  "version": "7.0.0",
   "description": "Base class for defining the behavior between screwdriver and source control management systems",
   "main": "index.js",
   "scripts": {
@@ -44,6 +44,6 @@
   },
   "dependencies": {
     "joi": "^17.2.0",
-    "screwdriver-data-schema": "git://github.com/screwdriver-cd/data-schema.git#hapi-v19"
+    "screwdriver-data-schema": "^20.0.0"
   }
 }

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:8
+    image: node:12
 
 jobs:
     main:


### PR DESCRIPTION
## Context

Screwdriver hapi.js dependencies are outdated and not supported anymore.

## Objective

This PR majorly upgrades @hapi/joi version and fixes all schema related changes to be compatible with latest @hapi js dependencies.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1958

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
