### PR TITLE
fix(1079): Fix autoDeployKeyGenerationEnabled to return a non promise flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ class ScmBase {
     }
 
     /**
-     * Parse the url for a repo for the specific source control
+     * Generate and add the public deploy key to the specific scm
      * @method addDeployKey
      * @param  {Object}    config                   Configuration
      * @param  {String}    config.checkoutUrl       Url to parse

--- a/index.js
+++ b/index.js
@@ -97,23 +97,6 @@ class ScmBase {
 
     /**
      * Parse the url for a repo for the specific source control
-     * @method addDeployKey
-     * @param  {Object}    config                   Configuration
-     * @param  {String}    config.checkoutUrl       Url to parse
-     * @param  {String}    config.token             The token used to authenticate to the SCM
-     * @param  {String}    [config.scmContext]      The scm context name
-     * @return {Promise}
-     */
-    addDeployKey(config) {
-        return this._addDeployKey(config);
-    }
-
-    _addDeployKey() {
-        return Promise.reject(new Error('Not implemented'));
-    }
-
-    /**
-     * Parse the url for a repo for the specific source control
      * @method parseUrl
      * @param  {Object}    config                   Configuration
      * @param  {String}    config.checkoutUrl       Url to parse

--- a/index.js
+++ b/index.js
@@ -97,6 +97,23 @@ class ScmBase {
 
     /**
      * Parse the url for a repo for the specific source control
+     * @method addDeployKey
+     * @param  {Object}    config                   Configuration
+     * @param  {String}    config.checkoutUrl       Url to parse
+     * @param  {String}    config.token             The token used to authenticate to the SCM
+     * @param  {String}    [config.scmContext]      The scm context name
+     * @return {Promise}
+     */
+    addDeployKey(config) {
+        return this._addDeployKey(config);
+    }
+
+    _addDeployKey() {
+        return Promise.reject(new Error('Not implemented'));
+    }
+
+    /**
+     * Parse the url for a repo for the specific source control
      * @method parseUrl
      * @param  {Object}    config                   Configuration
      * @param  {String}    config.checkoutUrl       Url to parse

--- a/index.js
+++ b/index.js
@@ -67,14 +67,10 @@ class ScmBase {
      * @method autoDeployKeyGenerationEnabled
      * @param  {Object}    config                   Configuration
      * @param  {String}    [config.scmContext]      The scm context name
-     * @return {Promise}
+     * @return {Boolean}
      */
-    autoDeployKeyGenerationEnabled(config) {
-        return this._autoDeployKeyGenerationEnabled(config);
-    }
-
-    _autoDeployKeyGenerationEnabled() {
-        return Promise.reject(new Error('Not implemented'));
+    autoDeployKeyGenerationEnabled() {
+        return this.config.autoDeployKeyGeneration || false;
     }
 
     /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -99,20 +99,20 @@ describe('index test', () => {
         );
     });
 
-    describe('checkAutoDeployKeyGeneration', () => {
+    describe('autoDeployKeyGenerationEnabled', () => {
         const autoDeployKeyGeneration = true;
 
         it('returns data from underlying method', () => {
-            instance._checkAutoDeployKeyGeneration = () => Promise.resolve(autoDeployKeyGeneration);
+            instance._autoDeployKeyGenerationEnabled = () => Promise.resolve(autoDeployKeyGeneration);
 
-            return instance.checkAutoDeployKeyGeneration()
+            return instance.autoDeployKeyGenerationEnabled()
                 .then((output) => {
                     assert.isBoolean(output, autoDeployKeyGeneration);
                 });
         });
 
         it('returns not implemented', () =>
-            instance.checkAutoDeployKeyGeneration()
+            instance.autoDeployKeyGenerationEnabled()
                 .then(() => {
                     assert.fail('This should not fail the test');
                 }, (err) => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -99,29 +99,6 @@ describe('index test', () => {
         );
     });
 
-    describe('autoDeployKeyGenerationEnabled', () => {
-        const autoDeployKeyGeneration = true;
-
-        it('returns data from underlying method', () => {
-            instance._autoDeployKeyGenerationEnabled = () =>
-                Promise.resolve(autoDeployKeyGeneration);
-
-            return instance.autoDeployKeyGenerationEnabled()
-                .then((output) => {
-                    assert.isBoolean(output, autoDeployKeyGeneration);
-                });
-        });
-
-        it('returns not implemented', () =>
-            instance.autoDeployKeyGenerationEnabled()
-                .then(() => {
-                    assert.fail('This should not fail the test');
-                }, (err) => {
-                    assert.equal(err.message, 'Not implemented');
-                })
-        );
-    });
-
     describe('parseHook', () => {
         const headers = {
             stuff: 'foo'
@@ -1131,6 +1108,25 @@ describe('index test', () => {
 
         it('returns valid display name', () => {
             assert.equal(instance.getDisplayName(), 'github.com');
+        });
+    });
+
+    describe('autoDeployKeyGenerationEnabled', () => {
+        const config = {
+            autoDeployKeyGeneration: true
+        };
+
+        beforeEach(() => {
+            instance.configure(config);
+        });
+
+        it('returns false if no configuration', () => {
+            instance.configure({});
+            assert.equal(instance.autoDeployKeyGenerationEnabled(), false);
+        });
+
+        it('returns valid autoDeployKeyGenerationEnabled flag', () => {
+            assert.equal(instance.autoDeployKeyGenerationEnabled(), true);
         });
     });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -99,6 +99,28 @@ describe('index test', () => {
         );
     });
 
+    describe('checkAutoDeployKeyGeneration', () => {
+        const autoDeployKeyGeneration = true;
+
+        it('returns data from underlying method', () => {
+            instance._checkAutoDeployKeyGeneration = () => Promise.resolve(autoDeployKeyGeneration);
+
+            return instance.checkAutoDeployKeyGeneration()
+                .then((output) => {
+                    assert.isBoolean(output, autoDeployKeyGeneration);
+                });
+        });
+
+        it('returns not implemented', () =>
+            instance.checkAutoDeployKeyGeneration()
+                .then(() => {
+                    assert.fail('This should not fail the test');
+                }, (err) => {
+                    assert.equal(err.message, 'Not implemented');
+                })
+        );
+    });
+
     describe('parseHook', () => {
         const headers = {
             stuff: 'foo'

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -103,7 +103,8 @@ describe('index test', () => {
         const autoDeployKeyGeneration = true;
 
         it('returns data from underlying method', () => {
-            instance._autoDeployKeyGenerationEnabled = () => Promise.resolve(autoDeployKeyGeneration);
+            instance._autoDeployKeyGenerationEnabled = () =>
+                Promise.resolve(autoDeployKeyGeneration);
 
             return instance.autoDeployKeyGenerationEnabled()
                 .then((output) => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -99,29 +99,6 @@ describe('index test', () => {
         );
     });
 
-    describe('autoDeployKeyGenerationEnabled', () => {
-        const autoDeployKeyGeneration = true;
-
-        it('returns data from underlying method', () => {
-            instance._autoDeployKeyGenerationEnabled = () =>
-                Promise.resolve(autoDeployKeyGeneration);
-
-            return instance.autoDeployKeyGenerationEnabled()
-                .then((output) => {
-                    assert.isBoolean(output, autoDeployKeyGeneration);
-                });
-        });
-
-        it('returns not implemented', () =>
-            instance.autoDeployKeyGenerationEnabled()
-                .then(() => {
-                    assert.fail('This should not fail the test');
-                }, (err) => {
-                    assert.equal(err.message, 'Not implemented');
-                })
-        );
-    });
-
     describe('parseHook', () => {
         const headers = {
             stuff: 'foo'


### PR DESCRIPTION
## Context

Fixes screwdriver-cd/screwdriver#1079

## Objective

This PR configures autoDeployKeyGenerationEnabled() to return a non-promise flag

## References

screwdriver-cd/screwdriver#1079

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
