### PR TITLE
fix: pass config properly to getWebhookEventsMapping

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,10 +65,12 @@ class ScmBase {
     /**
      * Get the webhook events mapping of screwdriver events and scm events
      * @method getWebhookEventsMapping
+     * @param  {Object}    config                   Configuration
+     * @param  {String}    [config.scmContext]      The scm context name
      * @return {Object}     Returns a mapping of the events
      */
-    getWebhookEventsMapping() {
-        return this._getWebhookEventsMapping();
+    getWebhookEventsMapping(config) {
+        return this._getWebhookEventsMapping(config);
     }
 
     _getWebhookEventsMapping() {


### PR DESCRIPTION
## Context

Create pipeline is crashing with following error

```(201013/223200.183, (1602628317442:sdapi-beta-6d88b98d8f-89zlr:19:kg8ga5lw:10688) [request,server,error] data: TypeError: Cannot read property 'scmContext' of undefined
    at ScmRouter._getWebhookEventsMapping (/usr/src/app/node_modules/screwdriver-scm-router/index.js:163:33)
    at ScmRouter.getWebhookEventsMapping (/usr/src/app/node_modules/screwdriver-scm-base/index.js:71:21)
    at /usr/src/app/node_modules/screwdriver-models/lib/pipeline.js:408:52
    at async handler (/usr/src/app/node_modules/screwdriver-api/plugins/pipelines/create.js:118:13)
    at async exports.Manager.execute (/usr/src/app/node_modules/@hapi/hapi/lib/toolkit.js:60:28)
    at async Object.internals.handler (/usr/src/app/node_modules/@hapi/hapi/lib/handler.js:46:20)
    at async exports.execute (/usr/src/app/node_modules/@hapi/hapi/lib/handler.js:31:20)
    at async Request._lifecycle (/usr/src/app/node_modules/@hapi/hapi/lib/request.js:370:32)
    at async Request._execute (/usr/src/app/node_modules/@hapi/hapi/lib/request.js:279:9)
201013/223157.442, (1602628317442:sdapi-beta-6d88b98d8f-89zlr:19:kg8ga5lw:10688) [response,api,pipelines] https://beta.api.screwdriver.cd: post /v4/pipelines {} 500 (2741ms))
```


## Objective

Pass configuration properly to `scm-router` function

## References

screwdriver-cd/screwdriver#1415

https://github.com/screwdriver-cd/scm-router/pull/27/files#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R162

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
