### PR TITLE
feat(2437): Add method to get read-only flag [2]

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,20 @@ The object consisting of PR comment ID, create time, and username.
 2. Reject if the input or output is not valid
 
 ### getScmContexts
+The parameters required are:
+
+| Parameter        | Type  | Required | Description |
+| :-------------   | :---- | :------- | :-------------|
+| config        | Object | Yes | Configuration Object |
+| config.hostname | String | Yes | The scm host name (ex: `github.com`) |
+
+#### Expected Outcome
+The matching scm context name string (e.g. github:github.com)
+
+#### Expected Response
+1. The matching scm context name
+
+### getScmContext
 No parameters are required.
 
 #### Expected Outcome
@@ -559,11 +573,14 @@ To make use of the validation functions, the functions to override are:
 1. `_getBellConfiguration`
 1. `_getPrInfo`
 1. `stats` 
-1. `_getScmContexts` 
+1. `_getScmContexts`
+1. `_getScmContext`
 1. `_canHandleWebhook` 
 1. `_getBranchList`
 1. `_openPr`
-1. `getDisplayName` (overriding needs only the case of `scm-router`) 
+1. `getDisplayName` (overriding needs only the case of `scm-router`)
+1. `readOnlyEnabled` (overriding needs only the case of `scm-router`) 
+
 
 ```js
 class MyScm extends ScmBase {

--- a/README.md
+++ b/README.md
@@ -508,6 +508,19 @@ The display name of scm context
 #### Expected Response
 1. The display name of scm context
 
+### readOnlyEnabled (overriding needs only the case of `scm-router`)
+The parameters required are:
+
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| scmContext        | String | Whether the SCM is read-only or not (default: `false`) |
+
+#### Expected Outcome
+Whether SCM is read-only or not
+
+#### Expected Response
+1. Whether SCM is read-only or not
+
 ### openPr
 | Parameter          | Type  | Required | Description |
 | :-------------     | :---- | :------- | :-------------|

--- a/README.md
+++ b/README.md
@@ -522,6 +522,19 @@ The display name of scm context
 #### Expected Response
 1. The display name of scm context
 
+### getUsername (overriding needs only the case of `scm-router`)
+The parameters required are:
+
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| scmContext        | String | The name of scm context |
+
+#### Expected Outcome
+The username of scm context
+
+#### Expected Response
+1. The username of scm context
+
 ### readOnlyEnabled (overriding needs only the case of `scm-router`)
 The parameters required are:
 
@@ -579,6 +592,7 @@ To make use of the validation functions, the functions to override are:
 1. `_getBranchList`
 1. `_openPr`
 1. `getDisplayName` (overriding needs only the case of `scm-router`)
+1. `getUsername` (overriding needs only the case of `scm-router`)
 1. `readOnlyEnabled` (overriding needs only the case of `scm-router`) 
 
 

--- a/README.md
+++ b/README.md
@@ -457,6 +457,15 @@ The object consisting of PR comment ID, create time, and username.
 2. Reject if the input or output is not valid
 
 ### getScmContexts
+No parameters are required.
+
+#### Expected Outcome
+The array of scm context names (e.g. [github:github.com, gitlab:my-gitlab])
+
+#### Expected Response
+1. The array of scm context names
+
+### getScmContext
 The parameters required are:
 
 | Parameter        | Type  | Required | Description |
@@ -469,15 +478,6 @@ The matching scm context name string (e.g. github:github.com)
 
 #### Expected Response
 1. The matching scm context name
-
-### getScmContext
-No parameters are required.
-
-#### Expected Outcome
-The array of scm context name (e.g. [github:github.com, gitlab:my-gitlab])
-
-#### Expected Response
-1. The array of scm context name
 
 ### canHandleWebhook
 The parameters required are:

--- a/README.md
+++ b/README.md
@@ -522,7 +522,7 @@ The display name of scm context
 #### Expected Response
 1. The display name of scm context
 
-### getUsername (overriding needs only the case of `scm-router`)
+### getReadOnlyInfo (overriding needs only the case of `scm-router`)
 The parameters required are:
 
 | Parameter        | Type  |  Description |
@@ -530,23 +530,10 @@ The parameters required are:
 | scmContext        | String | The name of scm context |
 
 #### Expected Outcome
-The username of scm context
+Read-only SCM config
 
 #### Expected Response
-1. The username of scm context
-
-### readOnlyEnabled (overriding needs only the case of `scm-router`)
-The parameters required are:
-
-| Parameter        | Type  |  Description |
-| :-------------   | :---- | :-------------|
-| scmContext        | String | Whether the SCM is read-only or not (default: `false`) |
-
-#### Expected Outcome
-Whether SCM is read-only or not
-
-#### Expected Response
-1. Whether SCM is read-only or not
+1. Read-only SCM config
 
 ### openPr
 | Parameter          | Type  | Required | Description |
@@ -592,8 +579,7 @@ To make use of the validation functions, the functions to override are:
 1. `_getBranchList`
 1. `_openPr`
 1. `getDisplayName` (overriding needs only the case of `scm-router`)
-1. `getUsername` (overriding needs only the case of `scm-router`)
-1. `readOnlyEnabled` (overriding needs only the case of `scm-router`) 
+1. `getReadOnlyInfo` (overriding needs only the case of `scm-router`) 
 
 
 ```js

--- a/index.js
+++ b/index.js
@@ -610,6 +610,15 @@ class ScmBase {
     }
 
     /**
+     * Get a username of scm context
+     * @method getUsername
+     * @return {String}
+     */
+    getUsername() {
+        return this.config.username || '';
+    }
+
+    /**
      * Whether SCM is read-only or not
      * @method readOnlyEnabled
      * @return {Boolean}

--- a/index.js
+++ b/index.js
@@ -590,6 +590,15 @@ class ScmBase {
     }
 
     /**
+     * Whether SCM is read-only or not
+     * @method readOnlyEnabled
+     * @return {Boolean}
+     */
+    readOnlyEnabled() {
+        return this.config.readOnly || false;
+    }
+
+    /**
      * Get the branch list related to the repository
      * @method getBranchList
      * @param  {Object}     config              Configuration

--- a/index.js
+++ b/index.js
@@ -235,11 +235,19 @@ class ScmBase {
             checkoutConfig.commitBranch = o.build.baseBranch;
         }
 
+        // Set parentConfig info
         if (o.configPipeline) {
             const parentConfig = { sha: o.configPipelineSha };
 
             [parentConfig.host, , parentConfig.branch] = o.configPipeline.scmUri.split(':');
             [parentConfig.org, parentConfig.repo] = o.configPipeline.scmRepo.name.split('/');
+
+            const readOnly = this.config.readOnly;
+
+            if (readOnly && Object.keys(readOnly).length !== 0) {
+                parentConfig.username = readOnly.username;
+                parentConfig.accessToken = readOnly.accessToken;
+            }
 
             checkoutConfig.parentConfig = parentConfig;
         }
@@ -610,21 +618,12 @@ class ScmBase {
     }
 
     /**
-     * Get a username of scm context
-     * @method getUsername
-     * @return {String}
+     * Get readOnly object
+     * @method getReadOnlyInfo
+     * @return {Object}
      */
-    getUsername() {
-        return this.config.username || '';
-    }
-
-    /**
-     * Whether SCM is read-only or not
-     * @method readOnlyEnabled
-     * @return {Boolean}
-     */
-    readOnlyEnabled() {
-        return this.config.readOnly || false;
+    getReadOnlyInfo() {
+        return this.config.readOnly || {};
     }
 
     /**

--- a/index.js
+++ b/index.js
@@ -566,6 +566,26 @@ class ScmBase {
     }
 
     /**
+     * Get a scm context matching given hostname
+     * @method getScmContext
+     * @param  {Object} config
+     * @param  {String} config.hostname Scm hostname (e.g. github.com or GHE.com)
+     * @return {String}                 Returns scm context (e.g. github:github.com
+     *                                  or github:GHE.com)
+     */
+    getScmContext(config) {
+        const result = this._getScmContext(config);
+        const schema = dataSchema.models.pipeline.base.extract('scmContext').required();
+        const validateResult = schema.validate(result);
+
+        return validateResult.error || result;
+    }
+
+    _getScmContext() {
+        throw new Error('Not implemented');
+    }
+
+    /**
      * Determine a scm module can handle the received webhook
      * @method canHandleWebhook
      * @param  {Object}     headers     The request headers associated with the webhook payload

--- a/index.js
+++ b/index.js
@@ -262,13 +262,6 @@ class ScmBase {
             [parentConfig.host, , parentConfig.branch] = o.configPipeline.scmUri.split(':');
             [parentConfig.org, parentConfig.repo] = o.configPipeline.scmRepo.name.split('/');
 
-            const readOnly = this.config.readOnly;
-
-            if (readOnly && Object.keys(readOnly).length !== 0) {
-                parentConfig.username = readOnly.username;
-                parentConfig.accessToken = readOnly.accessToken;
-            }
-
             checkoutConfig.parentConfig = parentConfig;
         }
 

--- a/index.js
+++ b/index.js
@@ -44,15 +44,14 @@ class ScmBase {
     /**
      * Set token correctly if is read-only SCM
      * @param  {Object} config
-     * @param  {String} [token]   SCM token
      * @return {Object}           Config with proper token
      */
     getConfig(config) {
         const newConfig = config;
-        const readOnlyToken = Hoek.reach(this.config, 'readOnly.accessToken');
+        const { accessToken, enabled } = Hoek.reach(this.config, 'readOnly', { default: {} });
 
-        if (newConfig && Hoek.reach(this.config, 'readOnly.enabled') && readOnlyToken) {
-            newConfig.token = readOnlyToken;
+        if (newConfig && enabled && accessToken) {
+            newConfig.token = accessToken;
 
             return newConfig;
         }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
   "dependencies": {
     "@hapi/hoek": "^9.1.0",
     "joi": "^17.2.0",
-    "screwdriver-data-schema": "^21.0.0"
+    "screwdriver-data-schema": "^21.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "nyc": "^15.0.0"
   },
   "dependencies": {
+    "@hapi/hoek": "^9.1.0",
     "joi": "^17.2.0",
     "screwdriver-data-schema": "^21.0.0"
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -429,9 +429,7 @@ describe('index test', () => {
                         host: 'github.com',
                         branch: 'master',
                         org: 'screwdriver-cd',
-                        repo: 'parent-to-guide',
-                        username: 'headlessbot',
-                        accessToken: 'sometoken'
+                        repo: 'parent-to-guide'
                     }
                 });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -84,6 +84,18 @@ describe('index test', () => {
     describe('addDeployKey', () => {
         const privKey = 'fakePrivateKey';
         const checkoutUrl = 'git@github.com:screwdriver-cd/data-model.git#master';
+        const config = { token, checkoutUrl };
+
+        it('returns error when invalid config object', () =>
+            instance.addDeployKey({})
+                .then(() => {
+                    assert.fail('you will never get dis');
+                })
+                .catch((err) => {
+                    assert.instanceOf(err, Error);
+                    assert.equal(err.name, 'ValidationError');
+                })
+        );
 
         it('returns data from underlying method', () => {
             instance._addDeployKey = () => Promise.resolve(privKey);
@@ -95,10 +107,11 @@ describe('index test', () => {
         });
 
         it('returns not implemented', () =>
-            instance.addDeployKey({ token, checkoutUrl })
+            instance.addDeployKey(config)
                 .then(() => {
-                    assert.fail('This should not fail the test');
-                }, (err) => {
+                    assert.fail('you will never get dis');
+                })
+                .catch((err) => {
                     assert.equal(err.message, 'Not implemented');
                 })
         );
@@ -572,11 +585,18 @@ describe('index test', () => {
     });
 
     describe('getPermissons', () => {
-        const config = {
+        const permConfig = {
             scmUri: 'github.com:repoId:branch',
             token,
             scmContext: 'github:github.com'
         };
+        const config = {
+            readOnly: readOnlyConfig
+        };
+
+        beforeEach(() => {
+            instance.configure(config);
+        });
 
         it('returns error when invalid config object', () =>
             instance.getPermissions({})
@@ -594,7 +614,7 @@ describe('index test', () => {
                 invalid: 'object'
             });
 
-            return instance.getPermissions(config)
+            return instance.getPermissions(permConfig)
                 .then(() => {
                     assert.fail('you will never get dis');
                 })
@@ -604,15 +624,28 @@ describe('index test', () => {
                 });
         });
 
-        it('returns not implemented', () =>
-            instance.getPermissions(config)
+        it('returns true permissions for read-only SCM', () =>
+            instance.getPermissions(permConfig)
+                .then((result) => {
+                    assert.deepEqual(result, {
+                        admin: true,
+                        push: true,
+                        pull: true
+                    });
+                })
+        );
+
+        it('returns not implemented', () => {
+            instance.configure({});
+
+            return instance.getPermissions(permConfig)
                 .then(() => {
                     assert.fail('you will never get dis');
                 })
                 .catch((err) => {
                     assert.equal(err.message, 'Not implemented');
-                })
-        );
+                });
+        });
     });
 
     describe('getOrgPermissions', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1060,6 +1060,25 @@ describe('index test', () => {
         });
     });
 
+    describe('getScmContext', () => {
+        it('returns error when invalid output', () => {
+            instance._getScmContext = () => 'invalid';
+
+            const result = instance.getScmContext({ hostname: 'github.com' });
+
+            assert.instanceOf(result, Error);
+            assert.equal(result.name, 'ValidationError');
+        });
+
+        it('returns not implemented', () => {
+            try {
+                instance.getScmContext({ hostname: 'github.com' });
+            } catch (err) {
+                assert.equal(err.message, 'Not implemented');
+            }
+        });
+    });
+
     describe('canHandleWebhook', () => {
         const headers = {
             stuff: 'foo'

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,6 +4,11 @@
 const assert = require('chai').assert;
 const token = 'token';
 const testParseHook = require('./data/parseHookOutput.json');
+const readOnlyConfig = {
+    enabled: true,
+    username: 'headlessbot',
+    accessToken: 'sometoken'
+};
 
 describe('index test', () => {
     let instance;
@@ -14,7 +19,7 @@ describe('index test', () => {
         ScmBase = require('../index');
         /* eslint-enable global-require */
 
-        instance = new ScmBase({ foo: 'bar' });
+        instance = new ScmBase({ foo: 'bar', readOnly: readOnlyConfig });
     });
 
     afterEach(() => {
@@ -402,16 +407,18 @@ describe('index test', () => {
                     org: 'screwdriver-cd',
                     repo: 'guide',
                     sha: '12345',
+                    scmContext: 'github:github.com',
+                    prRef: 'prRef',
                     prSource: 'branch',
                     prBranchName: 'prBranchName',
-                    prRef: 'prRef',
-                    scmContext: 'github:github.com',
                     parentConfig: {
-                        branch: 'master',
+                        sha: '54321',
                         host: 'github.com',
+                        branch: 'master',
                         org: 'screwdriver-cd',
                         repo: 'parent-to-guide',
-                        sha: '54321'
+                        username: 'headlessbot',
+                        accessToken: 'sometoken'
                     }
                 });
 
@@ -1130,28 +1137,9 @@ describe('index test', () => {
         });
     });
 
-    describe('getUsername', () => {
+    describe('getReadOnlyInfo', () => {
         const config = {
-            username: 'sd-buildbot'
-        };
-
-        beforeEach(() => {
-            instance.configure(config);
-        });
-
-        it('returns empty display name if no configuration', () => {
-            instance.configure({});
-            assert.equal(instance.getUsername(), '');
-        });
-
-        it('returns valid display name', () => {
-            assert.equal(instance.getUsername(), 'sd-buildbot');
-        });
-    });
-
-    describe('readOnlyEnabled', () => {
-        const config = {
-            readOnly: true
+            readOnly: readOnlyConfig
         };
 
         beforeEach(() => {
@@ -1160,11 +1148,11 @@ describe('index test', () => {
 
         it('returns false if no configuration', () => {
             instance.configure({});
-            assert.equal(instance.readOnlyEnabled(), false);
+            assert.deepEqual(instance.getReadOnlyInfo(), {});
         });
 
         it('returns actual boolean when set', () => {
-            assert.equal(instance.readOnlyEnabled(), true);
+            assert.deepEqual(instance.getReadOnlyInfo(), config.readOnly);
         });
     });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1130,6 +1130,25 @@ describe('index test', () => {
         });
     });
 
+    describe('getUsername', () => {
+        const config = {
+            username: 'sd-buildbot'
+        };
+
+        beforeEach(() => {
+            instance.configure(config);
+        });
+
+        it('returns empty display name if no configuration', () => {
+            instance.configure({});
+            assert.equal(instance.getUsername(), '');
+        });
+
+        it('returns valid display name', () => {
+            assert.equal(instance.getUsername(), 'sd-buildbot');
+        });
+    });
+
     describe('readOnlyEnabled', () => {
         const config = {
             readOnly: true

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1111,6 +1111,25 @@ describe('index test', () => {
         });
     });
 
+    describe('readOnlyEnabled', () => {
+        const config = {
+            readOnly: true
+        };
+
+        beforeEach(() => {
+            instance.configure(config);
+        });
+
+        it('returns false if no configuration', () => {
+            instance.configure({});
+            assert.equal(instance.readOnlyEnabled(), false);
+        });
+
+        it('returns actual boolean when set', () => {
+            assert.equal(instance.readOnlyEnabled(), true);
+        });
+    });
+
     describe('autoDeployKeyGenerationEnabled', () => {
         const config = {
             autoDeployKeyGeneration: true
@@ -1131,9 +1150,23 @@ describe('index test', () => {
     });
 
     describe('getWebhookEventsMapping', () => {
+        const webhookEventsMapping = {
+            pr: 'merge_requests_events',
+            commit: 'push_events'
+        };
+
+        it('returns data from underlying method', () => {
+            instance._getWebhookEventsMapping = () => Promise.resolve(webhookEventsMapping);
+
+            return instance.getWebhookEventsMapping()
+                .then((output) => {
+                    assert.deepEqual(output, webhookEventsMapping);
+                });
+        });
+
         it('returns not implemented', () => {
             try {
-                instance.getScmContexts();
+                instance.getWebhookEventsMapping({ scmContext: 'gitlab:gitlab.com' });
             } catch (err) {
                 assert.equal(err.message, 'Not implemented');
             }


### PR DESCRIPTION
## Context

We need to get data from the SCM config: read-only flag, scmContext.

## Objective

This PR:
- adds `getReadOnlyInfo()` method to return read-only SCM config
- adds `getConfig()` method to inject read-only token if read-only enabled
- adds `getScmContext()` method to get `scmContext` based on `hostname`
- adds/fixes tests for `getWebhooksEventsMapping()`

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2437

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
