### PR TITLE
fix(2437): Pass in headless user for decorateAuthor [1]

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,16 +42,22 @@ class ScmBase {
     }
 
     /**
-     * Set token correctly if is read-only SCM
-     * @param  {Object} config
+     * Set token and username correctly if is read-only SCM
+     * @param  {Object} config    Config to be passed into scm plugin
      * @return {Object}           Config with proper token
      */
     getConfig(config) {
         const newConfig = config;
-        const { accessToken, enabled } = Hoek.reach(this.config, 'readOnly', { default: {} });
+        const { accessToken, enabled, username } =
+            Hoek.reach(this.config, 'readOnly', { default: {} });
 
-        if (newConfig && enabled && accessToken) {
-            newConfig.token = accessToken;
+        if (newConfig && enabled) {
+            if (newConfig.token && accessToken) {
+                newConfig.token = accessToken;
+            }
+            if (newConfig.username && username) {
+                newConfig.username = username;
+            }
 
             return newConfig;
         }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
   "dependencies": {
     "@hapi/hoek": "^9.1.0",
     "joi": "^17.2.0",
-    "screwdriver-data-schema": "^21.3.1"
+    "screwdriver-data-schema": "^21.3.2"
   }
 }


### PR DESCRIPTION
## Context

Would be nice if proper username was used for `decorateAuthor` in event create.

## Objective

This PR passes in proper headless `username` to `decorateAuthor` when read-only SCM enabled.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2437, #87 

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
