### PR TITLE
fix: semantic release by removing verifyConditions

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,10 +33,7 @@
     "branches": [
       "master"
     ],
-    "debug": false,
-    "verifyConditions": {
-      "path": "./node_modules/semantic-release/src/lib/plugin-noop.js"
-    }
+    "debug": false
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -147,7 +147,7 @@ describe('index test', () => {
 
     describe('getChangedFiles', () => {
         const type = 'pr';
-        const payload = {
+        const webhookConfig = {
             type
         };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -166,7 +166,7 @@ describe('index test', () => {
                 });
 
             return instance
-                .getChangedFiles({ type, payload, token })
+                .getChangedFiles({ type, webhookConfig, token })
                 .then(() => {
                     assert.fail('you will never get dis');
                 })
@@ -177,7 +177,7 @@ describe('index test', () => {
         });
 
         it('returns not implemented', () =>
-            instance.getChangedFiles({ type, payload, token }).then(
+            instance.getChangedFiles({ type, webhookConfig, token }).then(
                 () => {
                     assert.fail('This should not fail the test');
                 },


### PR DESCRIPTION
## Context

getChangedFiles test is failing after new data-schema changes (https://github.com/screwdriver-cd/data-schema/pull/471).
Also semantic release will fail.

## Objective

This PR fixes getChangedFiles test and verifyConditions for semantic release.

## References

Related to https://github.com/screwdriver-cd/scm-base/pull/90
## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
