### PR TITLE
fix(2952): Allow colon to be used in root directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -220,7 +220,10 @@ class ScmBase {
      * @return {Promise}
      */
     getSetupCommand(o) {
-        const [host, , branch, rootDir] = o.pipeline.scmUri.split(':');
+        const parts = o.pipeline.scmUri.split(':');
+        const [host, , branch, ...rootDirParts] = parts;
+        const rootDir = rootDirParts.join(':');
+
         const [org, repo] = o.pipeline.scmRepo.name.split('/');
         const prBranchRegex = /^~pr:(.*)$/;
         const checkoutConfig = {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -306,6 +306,30 @@ describe('index test', () => {
             });
         });
 
+        it('returns a command when rootDir with a colon exists', () => {
+            config.pipeline.scmUri = 'github.com:12344567:branch:colon:colon';
+            instance._getCheckoutCommand = o => {
+                assert.deepEqual(o, {
+                    branch: 'branch',
+                    host: 'github.com',
+                    org: 'screwdriver-cd',
+                    repo: 'guide',
+                    rootDir: 'colon:colon',
+                    sha: '12345',
+                    prSource: 'branch',
+                    prBranchName: 'prBranchName',
+                    prRef: 'prRef',
+                    scmContext: 'github:github.com'
+                });
+
+                return Promise.resolve({ name: 'sd-checkout-code', command: 'stuff' });
+            };
+
+            return instance.getSetupCommand(config).then(command => {
+                assert.equal(command, 'stuff');
+            });
+        });
+
         it('returns a command for pr', () => {
             instance._getCheckoutCommand = o => {
                 assert.deepEqual(o, {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Cannot start build if rootDirectory contains a colon.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
I fix to correctly parse rootDirectory even if it contains a colon.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
issue: https://github.com/screwdriver-cd/screwdriver/issues/2952

PR:
- https://github.com/screwdriver-cd/scm-github/pull/220
- https://github.com/screwdriver-cd/launcher/pull/469
- https://github.com/screwdriver-cd/data-schema/pull/544

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
