### PR TITLE
fix(3384): Failure to get user info from scm should not throw error

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "@hapi/hoek": "^11.0.7",
     "joi": "^17.13.3",
-    "screwdriver-data-schema": "^25.0.0"
+    "screwdriver-data-schema": "^25.0.0",
+    "screwdriver-logger": "^3.0.0"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -596,12 +596,38 @@ describe('index test', () => {
         it('returns not implemented', () =>
             instance
                 .decorateAuthor(config)
-                .then(() => {
-                    assert.fail('you will never get dis');
+                .then(author => {
+                    assert.deepEqual(
+                        {
+                            id: '',
+                            avatar: 'https://cd.screwdriver.cd/assets/unknown_user.png',
+                            name: config.username,
+                            username: config.username,
+                            url: 'https://cd.screwdriver.cd/'
+                        },
+                        author
+                    );
                 })
                 .catch(err => {
                     assert.equal(err.message, 'Not implemented');
                 }));
+
+        it('returns default author when there is a failure get author from scm', () => {
+            instance._decorateAuthor = () => Promise.reject(new Error('User profile does not exist'));
+
+            return instance.decorateAuthor(config).then(author => {
+                assert.deepEqual(
+                    {
+                        id: '',
+                        avatar: 'https://cd.screwdriver.cd/assets/unknown_user.png',
+                        name: config.username,
+                        username: config.username,
+                        url: 'https://cd.screwdriver.cd/'
+                    },
+                    author
+                );
+            });
+        });
     });
 
     describe('getPermissons', () => {


### PR DESCRIPTION
## Context
`decorateAuthor()` could throw an error when the user profile does not exist in the scm for the specified login.
This error bubbles up to the caller and breaks certain workflows.
Ex:
Event creation failed when there is a failure to get user info from the scm.

All of these additional info are optional and mostly used for display purpose in the UI.

## Objective
Do not bubble up the error to the caller. Instead set default values for these optional fields.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3384

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
