### PR TITLE
fix: Verify signature of payloads containing control characters [1]

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,7 +163,7 @@ class ScmBase {
      * Parse the webhook for the specific source control
      * @method parseHook
      * @param  {Object}     headers     The request headers associated with the webhook payload
-     * @param  {Object}     payload     The webhook payload received from the SCM service
+     * @param  {String}     payload     The webhook payload received from the SCM service
      * @return {Promise}
      */
     parseHook(headers, payload) {
@@ -666,7 +666,7 @@ class ScmBase {
      * Determine a scm module can handle the received webhook
      * @method canHandleWebhook
      * @param  {Object}     headers     The request headers associated with the webhook payload
-     * @param  {Object}     payload     The webhook payload received from the SCM service
+     * @param  {String}     payload     The webhook payload received from the SCM service
      * @return {Promise}
      */
     canHandleWebhook(headers, payload) {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

When JSON.stringify() is applied to certain control characters, their character representation changes.

```
> JSON.stringify({x: '\u001F'})
'{"x":"\\u001f"}'
> JSON.stringify({x: '\x1F'})
'{"x":"\\u001f"}'
```

Therefore, if you use the value obtained by re-stringifying the payload after JSON.parse for verifying the signature, it will fail because the contents do not match.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

- The original payload will be used for signature verification.
- Enable passing the string before parsing to the _parseHook in scm components.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

- https://github.com/screwdriver-cd/scm-base/pull/102
- https://github.com/screwdriver-cd/scm-github/pull/250
- https://github.com/screwdriver-cd/scm-gitlab/pull/74
- https://github.com/screwdriver-cd/scm-bitbucket/pull/102
- https://github.com/screwdriver-cd/scm-router/pull/39
- https://github.com/screwdriver-cd/screwdriver/pull/3407

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
